### PR TITLE
Bugs Fix By `getStat` Function

### DIFF
--- a/chain/ante/fee.go
+++ b/chain/ante/fee.go
@@ -125,6 +125,10 @@ func checkPayerAuth(ctx sdk.Context, ak AccountKeeper, tx sdk.Tx, simulate bool,
 	}
 
 	acc := ak.GetAccount(ctx, payer)
+	if acc == nil {
+		return sdkerrors.Wrap(sdkerrors.ErrUnknownAddress, "payer not found")
+	}
+
 	accAuth := acc.GetAuth()
 
 	if !isHasAuth(auths, accAuth) {

--- a/chain/client/txutil/context.go
+++ b/chain/client/txutil/context.go
@@ -53,8 +53,5 @@ func (k KuCLIContext) WithOutput(w io.Writer) KuCLIContext {
 
 // GetAccountInfo get account info by from account id
 func (k KuCLIContext) GetAccountInfo() (exported.Account, error) {
-	id := k.GetAccountID()
-
-	getter := NewAccountRetriever(k)
-	return getter.GetAccount(id)
+	return NewAccountRetriever(k).GetAccount(k.GetAccountID())
 }

--- a/chain/client/txutil/tx.go
+++ b/chain/client/txutil/tx.go
@@ -7,16 +7,14 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/viper"
-
+	"github.com/KuChain-io/kuchain/chain/types"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/codec"
-
-	"github.com/KuChain-io/kuchain/chain/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 )
 
 // GasEstimateResponse defines a response definition for tx gas estimation.
@@ -339,6 +337,10 @@ func QueryAccountAuth(cliCtx KuCLIContext, id types.AccountID) (types.AccAddress
 		acc, err := getter.GetAccount(id)
 		if err != nil {
 			return types.AccAddress{}, err
+		}
+
+		if acc == nil {
+			return types.AccAddress{}, errors.New("account not found")
 		}
 
 		return acc.GetAuth(), nil

--- a/x/account/types/account_retriever.go
+++ b/x/account/types/account_retriever.go
@@ -98,6 +98,10 @@ func (ar AccountRetriever) GetAuthNumberSequence(id types.AccountID) (uint64, ui
 		if err != nil {
 			return 0, 0, err
 		}
+
+		if acc == nil {
+			return 0, 0, ErrAccountNoFound
+		}
 		auth = acc.GetAuth()
 	}
 

--- a/x/asset/keeper/keeper_internal.go
+++ b/x/asset/keeper/keeper_internal.go
@@ -140,7 +140,7 @@ func (a AssetKeeper) getStat(ctx sdk.Context, creator, symbol types.Name) (*type
 	store := ctx.KVStore(a.key)
 	bz := store.Get(types.CoinStatStoreKey(creator, symbol))
 	if bz == nil {
-		return nil, nil
+		return nil, types.ErrAssetCoinNoExit
 	}
 
 	var stat types.CoinStat
@@ -166,7 +166,7 @@ func (a AssetKeeper) getDescription(ctx sdk.Context, creator, symbol types.Name)
 	store := ctx.KVStore(a.key)
 	bz := store.Get(types.CoinDescStoreKey(creator, symbol))
 	if bz == nil {
-		return nil, nil
+		return nil, types.ErrAssetCoinNoExit
 	}
 
 	var res types.CoinDescription


### PR DESCRIPTION
In Kuchain, if just panic in some get function for keeper will make tx exec error not clear to show reason.

So we need check some nil checker to getter response.

Thanks:

@Jdkhnjggf