### PR TITLE
Add Build Params for Chain Symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 
+MAIN_SYMBOL := 'kuchain'
+CORE_SYMBOL := 'sys'
+
 export GO111MODULE = on
 
 # process build tags
@@ -48,12 +51,14 @@ build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
 
 # process linker flags
 
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=kuchain \
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=$(MAIN_SYMBOL) \
 		  -X github.com/cosmos/cosmos-sdk/version.ServerName=kucd \
 		  -X github.com/cosmos/cosmos-sdk/version.ClientName=kucli \
 		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
-		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
+		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
+		  -X github.com/KuChainNetwork/kuchain/chain/constants/keys.ChainNameStr=$(CORE_SYMBOL) \
+		  -X github.com/KuChainNetwork/kuchain/chain/constants/keys.ChainMainNameStr=$(MAIN_SYMBOL)
 
 ifeq ($(WITH_CLEVELDB),yes)
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=cleveldb

--- a/chain/config/config.go
+++ b/chain/config/config.go
@@ -14,9 +14,6 @@ import (
 )
 
 const (
-	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
-	Bech32MainPrefix = keys.ChainMainNameStr
-
 	// Will Set For https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 	CoinType = 23808
 
@@ -37,6 +34,11 @@ const (
 
 	// PrefixAddress is the prefix for addresses
 	PrefixAddress = "addr"
+)
+
+var (
+	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
+	Bech32MainPrefix = keys.ChainMainNameStr
 
 	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
 	Bech32PrefixAccAddr = Bech32MainPrefix

--- a/chain/constants/gas.go
+++ b/chain/constants/gas.go
@@ -4,7 +4,7 @@ import (
 	"github.com/KuChainNetwork/kuchain/chain/types"
 )
 
-const (
+var (
 	MinGasPriceString        = "0.01" + DefaultBondDenom
 	GasTxSizePrice    uint64 = 5
 )

--- a/chain/constants/keys/keys.go
+++ b/chain/constants/keys/keys.go
@@ -1,6 +1,6 @@
 package keys
 
-const (
+var (
 	ChainNameStr      = "sys"
 	ChainMainNameStr  = "kuchain"
 	DefaultBondSymbol = ChainNameStr

--- a/chain/constants/names.go
+++ b/chain/constants/names.go
@@ -7,7 +7,7 @@ import (
 	"github.com/KuChainNetwork/kuchain/chain/types"
 )
 
-const (
+var (
 	ChainNameStr      = keys.ChainNameStr
 	ChainMainNameStr  = keys.ChainMainNameStr
 	DefaultBondDenom  = keys.DefaultBondDenom

--- a/scripts/boot-testnet.sh
+++ b/scripts/boot-testnet.sh
@@ -4,6 +4,9 @@ ROOT_DIR=$1
 NULL=
 CHAIN_ID="testing"
 
+MAIN_SYMBOL='kuchain'
+CORE_SYMBOL='sys'
+
 printf "params $1 $2\\n"
 
 ROOT_DIR="${ROOT_DIR}/${CHAIN_ID}"
@@ -17,9 +20,9 @@ printf "start testnet for kuchain ${CHAIN_ID} in ${ROOT_DIR}\\n"
 PARAMS="--home ${ROOT_DIR}/node/"
 PARAMSCLI="--home ${ROOT_DIR}/cli/ --keyring-backend test"
 
-./build/kucli ${PARAMSCLI} keys add kuchain
+./build/kucli ${PARAMSCLI} keys add ${MAIN_SYMBOL}
 
-VALKEY=$(./build/kucli ${PARAMSCLI} keys show kuchain -a)
+VALKEY=$(./build/kucli ${PARAMSCLI} keys show ${MAIN_SYMBOL} -a)
 
 ./build/kucli ${PARAMSCLI} keys add test
 
@@ -28,17 +31,17 @@ TESTVALKEY=$(./build/kucli ${PARAMSCLI} keys show test -a)
 printf "current val key ${VALKEY}\\n"
 
 ./build/kucd init ${PARAMS} --chain-id=${CHAIN_ID} ${CHAIN_ID}
-./build/kucd ${PARAMS} genesis add-account kuchain ${VALKEY}
+./build/kucd ${PARAMS} genesis add-account ${MAIN_SYMBOL} ${VALKEY}
 ./build/kucd ${PARAMS} genesis add-account testacc1 ${TESTVALKEY}
 ./build/kucd ${PARAMS} genesis add-account testacc2 ${TESTVALKEY}
 ./build/kucd ${PARAMS} genesis add-address ${VALKEY}
-./build/kucd ${PARAMS} genesis add-coin "1000000000000000000000000000000000000000kuchain/sys" "main token"
+./build/kucd ${PARAMS} genesis add-coin "1000000000000000000000000000000000000000${MAIN_SYMBOL}/${CORE_SYMBOL}" "main token"
 #./build/kucd ${PARAMS} genesis add-coin "1000000000000000000000000000000000000000validatortoken" "for staking"
-./build/kucd ${PARAMS} genesis add-account-coin ${VALKEY} "100000000000000000000000kuchain/sys"
-./build/kucd ${PARAMS} genesis add-account-coin kuchain "100000000000000000000000kuchain/sys"
+./build/kucd ${PARAMS} genesis add-account-coin ${VALKEY} "100000000000000000000000${MAIN_SYMBOL}/${CORE_SYMBOL}"
+./build/kucd ${PARAMS} genesis add-account-coin ${MAIN_SYMBOL} "100000000000000000000000${MAIN_SYMBOL}/${CORE_SYMBOL}"
 
-printf "./build/kucd ${PARAMS} gentx ${VALKEY} --keyring-backend test --name kuchain --home-client ${ROOT_DIR}/cli/\\n"
-./build/kucd ${PARAMS} gentx ${VALKEY} --keyring-backend test --name kuchain --home-client ${ROOT_DIR}/cli/
+printf "./build/kucd ${PARAMS} gentx ${VALKEY} --keyring-backend test --name ${MAIN_SYMBOL} --home-client ${ROOT_DIR}/cli/\\n"
+./build/kucd ${PARAMS} gentx ${VALKEY} --keyring-backend test --name ${MAIN_SYMBOL} --home-client ${ROOT_DIR}/cli/
 
 
 ./build/kucd ${PARAMS} collect-gentxs

--- a/x/staking/exported/staking.go
+++ b/x/staking/exported/staking.go
@@ -9,7 +9,7 @@ import (
 )
 
 // staking constants
-const (
+var (
 
 	// default bond denomination
 	DefaultBondDenom = constants.DefaultBondDenom


### PR DESCRIPTION
In Kuchain, now we will use kuchain/sys as the core token for chain, but in some use, we need change this to others, so we add param defs in Makefile, so we can chose it in build.

in makefile, we add two defines :

- MAIN_SYMBOL : it will define main symbol for chain, like root account or address prefix
- CORE_SYMBOL : it will define main core symbol for chain, like system account @xxx

user could use` make -e CORE_SYMBOL=aaa -e MAIN_SYMBOL=bbb` to set symbol in build