### PR TITLE
Fix Msg ValidateBase No Called By Type Receiver Error

### DIFF
--- a/x/gov/handle_test.go
+++ b/x/gov/handle_test.go
@@ -254,6 +254,12 @@ func TestGovHandler(t *testing.T) {
 		//deposit
 		err = disposit(t, wallet, app, addAlice, accAlice, 1, types.Coins{depositAsset}, true)
 		So(err, ShouldBeNil)
+		//wrong coins
+		depositCoins := types.Coins{depositAsset}
+		initCoins := types.Coins{initdepost}
+		wrongCoin,_ := initCoins.SafeSub(depositCoins)
+		err = disposit(t, wallet, app, addAlice, accAlice, 1, wrongCoin, false)
+		So(err, ShouldNotBeNil)
 		//deposit after proposal have enough coin
 		err = disposit(t, wallet, app, addAlice, accAlice, 1, types.Coins{depositAsset}, true)
 		So(err, ShouldBeNil)

--- a/x/gov/types/kumsg.go
+++ b/x/gov/types/kumsg.go
@@ -97,6 +97,14 @@ func NewKuMsgDeposit(auth sdk.AccAddress, depositor AccountID, proposalID uint64
 	}
 }
 
+func (msg KuMsgDeposit) ValidateBasic() error {
+	msgData := MsgDeposit{}
+	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
+		return err
+	}
+ 	return msgData.ValidateBasic()
+}
+
 type KuMsgVote struct {
 	KuMsg
 }
@@ -109,6 +117,14 @@ func NewKuMsgVote(auth sdk.AccAddress, voter AccountID, proposalID uint64, optio
 			msg.WithData(Cdc(), &MsgVote{proposalID, voter, option}),
 		),
 	}
+}
+
+func (msg KuMsgVote) ValidateBasic() error {
+	msgData := MsgVote{}
+	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
+		return err
+	}
+ 	return msgData.ValidateBasic()
 }
 
 type MsgGovUnJail struct {

--- a/x/gov/types/kumsg.go
+++ b/x/gov/types/kumsg.go
@@ -30,6 +30,9 @@ func NewKuMsgSubmitProposal(auth sdk.AccAddress, content Content, initialDeposit
 }
 
 func (msg KuMsgSubmitProposal) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateBasic(); err != nil {
+		return err
+	}
 	if msg.Content == nil {
 		return sdkerrors.Wrap(ErrInvalidProposalContent, "missing content")
 	}
@@ -98,6 +101,9 @@ func NewKuMsgDeposit(auth sdk.AccAddress, depositor AccountID, proposalID uint64
 }
 
 func (msg KuMsgDeposit) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateBasic(); err != nil {
+		return err
+	}
 	msgData := MsgDeposit{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
@@ -120,6 +126,9 @@ func NewKuMsgVote(auth sdk.AccAddress, voter AccountID, proposalID uint64, optio
 }
 
 func (msg KuMsgVote) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateBasic(); err != nil {
+		return err
+	}
 	msgData := MsgVote{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err

--- a/x/slashing/types/kumsg.go
+++ b/x/slashing/types/kumsg.go
@@ -26,6 +26,9 @@ func NewKuMsgUnjail(auth sdk.AccAddress, validatorAddr AccountID) KuMsgUnjail {
 }
 
 func (msg KuMsgUnjail) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateBasic(); err != nil {
+		return err
+	}
 	msgData := MsgUnjail{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err

--- a/x/slashing/types/kumsg.go
+++ b/x/slashing/types/kumsg.go
@@ -24,3 +24,11 @@ func NewKuMsgUnjail(auth sdk.AccAddress, validatorAddr AccountID) KuMsgUnjail {
 		),
 	}
 }
+
+func (msg KuMsgUnjail) ValidateBasic() error {
+	msgData := MsgUnjail{}
+	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
+		return err
+	}
+ 	return msgData.ValidateBasic()
+}

--- a/x/staking/handler_test.go
+++ b/x/staking/handler_test.go
@@ -227,12 +227,18 @@ func TestStakingHandler(t *testing.T) {
 		//alice D jack 50000000
 		err = delegationValidator(t, wallet, app, addAlice, accAlice, accJack, delegateAmount, true)
 		So(err, ShouldBeNil)
-
+		//wrong coin delegate
+		wrongAmount := types.Coin{Denom:constants.DefaultBondDenom, Amount:sdk.NewInt(-5000000)}
+		err = delegationValidator(t, wallet, app, addValidator, accValidator, accJack, wrongAmount, false)
+		So(err, ShouldNotBeNil)
 		// coin not enought
 		err = delegationValidator(t, wallet, app, addValidator, accValidator, accJack, delegateAmount, false)
 		So(err, ShouldNotBeNil)
 		// not exist validator
 		err = delegationValidator(t, wallet, app, addAlice, accAlice, accValidator, delegateAmount, false)
+		So(err, ShouldNotBeNil)
+		//wrong coin redelegate
+		err = redelegateValidator(t, wallet, app, addAlice, accAlice, accJack, accAlice, wrongAmount, false)
 		So(err, ShouldNotBeNil)
 		//right   alice R jack T alice 50000
 		err = redelegateValidator(t, wallet, app, addAlice, accAlice, accJack, accAlice, smallAmount, true)
@@ -252,6 +258,9 @@ func TestStakingHandler(t *testing.T) {
 		//alice U jack 50000
 		err = unbondValidator(t, wallet, app, addAlice, accAlice, accJack, smallAmount, true)
 		So(err, ShouldBeNil)
+		//wrong coin unbond
+		err = unbondValidator(t, wallet, app, addAlice, accAlice, accJack, wrongAmount, false)
+		So(err, ShouldNotBeNil)
 		//alice U jack 50000000
 		err = unbondValidator(t, wallet, app, addAlice, accAlice, accJack, bigAmount, false)
 		So(err, ShouldNotBeNil)

--- a/x/staking/types/kumsg.go
+++ b/x/staking/types/kumsg.go
@@ -41,6 +41,9 @@ func NewKuMsgCreateValidator(auth sdk.AccAddress, valAddr chainTypes.AccountID, 
 }
 
 func (msg KuMsgCreateValidator) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateBasic(); err != nil {
+		return err
+	}
 	msgData := MsgCreateValidator{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
@@ -69,6 +72,9 @@ func NewKuMsgDelegate(auth sdk.AccAddress, delAddr chainTypes.AccountID, valAddr
 }
 
 func (msg KuMsgDelegate) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateBasic(); err != nil {
+		return err
+	}
 	msgData := MsgDelegate{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
@@ -96,6 +102,9 @@ func NewKuMsgEditValidator(auth sdk.AccAddress, valAddr chainTypes.AccountID, de
 }
 
 func (msg KuMsgEditValidator) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateBasic(); err != nil {
+		return err
+	}
 	msgData := MsgEditValidator{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
@@ -124,6 +133,9 @@ func NewKuMsgRedelegate(auth sdk.AccAddress, delAddr chainTypes.AccountID, valSr
 }
 
 func (msg KuMsgRedelegate) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateBasic(); err != nil {
+		return err
+	}
 	msgData := MsgBeginRedelegate{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
@@ -151,6 +163,9 @@ func NewKuMsgUnbond(auth sdk.AccAddress, delAddr chainTypes.AccountID, valAddr c
 }
 
 func (msg KuMsgUnbond) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateBasic(); err != nil {
+		return err
+	}
 	msgData := MsgUndelegate{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err

--- a/x/staking/types/kumsg.go
+++ b/x/staking/types/kumsg.go
@@ -40,6 +40,14 @@ func NewKuMsgCreateValidator(auth sdk.AccAddress, valAddr chainTypes.AccountID, 
 	}
 }
 
+func (msg KuMsgCreateValidator) ValidateBasic() error {
+	msgData := MsgCreateValidator{}
+	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
+		return err
+	}
+ 	return msgData.ValidateBasic()
+}
+
 type KuMsgDelegate struct {
 	chainTypes.KuMsg
 }
@@ -60,6 +68,14 @@ func NewKuMsgDelegate(auth sdk.AccAddress, delAddr chainTypes.AccountID, valAddr
 	}
 }
 
+func (msg KuMsgDelegate) ValidateBasic() error {
+	msgData := MsgDelegate{}
+	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
+		return err
+	}
+ 	return msgData.ValidateBasic()
+}
+
 type KuMsgEditValidator struct {
 	chainTypes.KuMsg
 }
@@ -77,6 +93,14 @@ func NewKuMsgEditValidator(auth sdk.AccAddress, valAddr chainTypes.AccountID, de
 			}),
 		),
 	}
+}
+
+func (msg KuMsgEditValidator) ValidateBasic() error {
+	msgData := MsgEditValidator{}
+	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
+		return err
+	}
+ 	return msgData.ValidateBasic()
 }
 
 type KuMsgRedelegate struct {
@@ -99,6 +123,14 @@ func NewKuMsgRedelegate(auth sdk.AccAddress, delAddr chainTypes.AccountID, valSr
 	}
 }
 
+func (msg KuMsgRedelegate) ValidateBasic() error {
+	msgData := MsgBeginRedelegate{}
+	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
+		return err
+	}
+ 	return msgData.ValidateBasic()
+}
+
 type KuMsgUnbond struct {
 	chainTypes.KuMsg
 }
@@ -116,4 +148,12 @@ func NewKuMsgUnbond(auth sdk.AccAddress, delAddr chainTypes.AccountID, valAddr c
 			}),
 		),
 	}
+}
+
+func (msg KuMsgUnbond) ValidateBasic() error {
+	msgData := MsgUndelegate{}
+	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
+		return err
+	}
+ 	return msgData.ValidateBasic()
 }


### PR DESCRIPTION
add ValidateBasic to this msg:

- KuMsgDeposit
- KuMsgVote
- KuMsgUnjail
- KuMsgCreateValidator
- KuMsgDelegate
- KuMsgEditValidator
- KuMsgRedelegate
- KuMsgUnbond

add test in handle_test.go.