### PR TITLE
Fix Test Check Failed By Coins not sorted in Test

### DIFF
--- a/chain/ante/ante_test.go
+++ b/chain/ante/ante_test.go
@@ -44,15 +44,15 @@ var (
 )
 
 func createAppForTest() (*simapp.SimApp, sdk.Context) {
-	asset1 := types.Coins{
+	asset1 := types.NewCoins(
 		types.NewInt64Coin("foo/coin", 1000000000000000),
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
-	asset2 := types.Coins{
+		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000))
+	asset2 := types.NewCoins(
 		types.NewInt64Coin("foo/coin", 1000000000000000),
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
-	asset3 := types.Coins{
+		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000))
+	asset3 := types.NewCoins(
 		types.NewInt64Coin("foo/coin", 1000000000000000),
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000))
 
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(),
 		simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1),
@@ -78,7 +78,7 @@ func testStdTx(app *simapp.SimApp, ids ...types.AccountID) types.StdTx {
 			from = id
 			addr = wallet.GetAuth(id)
 			to   = account1
-			amt  = types.Coins{types.NewCoin("foo/coin", types.NewInt(10))}
+			amt  = types.NewCoins(types.NewCoin("foo/coin", types.NewInt(10)))
 		)
 
 		// a createMsg

--- a/chain/ante/fee_test.go
+++ b/chain/ante/fee_test.go
@@ -133,11 +133,11 @@ func TestEnsureMempoolFees(t *testing.T) {
 
 		atomPrice := types.NewDecCoinFromDec(constants.DefaultBondDenom,
 			types.NewDec(200).Quo(types.NewDec(100000))) // 200 coin
-		highGasPrice := types.DecCoins{atomPrice}
+		highGasPrice := types.NewDecCoins(atomPrice)
 
 		atomPrice = types.NewDecCoinFromDec(constants.DefaultBondDenom,
 			types.NewDec(0).Quo(types.NewDec(100000)))
-		lowGasPrice := types.DecCoins{atomPrice}
+		lowGasPrice := types.NewDecCoins(atomPrice)
 
 		Convey("Decorator should have error on too low fee for local gasPrice", func() {
 			// Set high gas price so standard test fee fails

--- a/chain/types/coin.go
+++ b/chain/types/coin.go
@@ -25,6 +25,7 @@ var (
 	NewDecCoinsFromCoins = coin.NewDecCoinsFromCoins
 	NewDecCoinFromDec    = coin.NewDecCoinFromDec
 	NewInt64Coin         = coin.NewInt64Coin
+	NewInt64Coins        = coin.NewInt64Coins
 	NewInt               = coin.NewInt
 	ParseCoin            = coin.ParseCoin
 	ParseCoins           = coin.ParseCoins

--- a/chain/types/coin/coin.go
+++ b/chain/types/coin/coin.go
@@ -174,6 +174,12 @@ func NewCoins(coins ...Coin) Coins {
 	return newCoins
 }
 
+// NewInt64Coins returns a new coin with a denomination and amount. It will panic
+// if the amount is negative.
+func NewInt64Coins(denom string, amount int64) Coins {
+	return NewCoins(NewCoin(denom, NewInt(amount)))
+}
+
 type coinsJSON Coins
 
 // MarshalJSON implements a custom JSON marshaller for the Coins type to allow

--- a/chain/types/coin/coin_test.go
+++ b/chain/types/coin/coin_test.go
@@ -1,0 +1,50 @@
+package coin_test
+
+import (
+	"testing"
+
+	"github.com/KuChainNetwork/kuchain/chain/types/coin"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	ld1 = "chain/sys"
+	ld2 = "aaaaaaa/cccc"
+)
+
+func TestSubLittleCoinDenom(t *testing.T) {
+	Convey("test safe sub", t, func() {
+		cc1 := coin.Coins{
+			coin.NewInt64Coin(ld1, 1000),
+			coin.NewInt64Coin(ld2, 2000),
+		}
+
+		cc2 := coin.Coins{
+			coin.NewInt64Coin(ld1, 100),
+		}
+
+		cc1m2, isNeg := cc1.SafeSub(cc2)
+		So(isNeg, ShouldBeFalse)
+
+		t.Logf("cc1m2 %s %v", cc1m2.String(), cc1m2.AmountOf(ld1))
+		t.Logf("cc1m2 0 %s %v", cc1m2[0].Denom, cc1m2[0].Amount)
+		t.Logf("cc1m2 1 %s %v", cc1m2[1].Denom, cc1m2[1].Amount)
+
+		cc1m2 = cc1m2.Sort()
+		t.Logf("cc1m2 %s %v", cc1m2.String(), cc1m2.AmountOf(ld1))
+		t.Logf("cc1m2 0 %s %v", cc1m2[0].Denom, cc1m2[0].Amount)
+		t.Logf("cc1m2 1 %s %v", cc1m2[1].Denom, cc1m2[1].Amount)
+
+		So(len(cc1m2), ShouldEqual, 2)
+		So(cc1m2.AmountOf(ld1).Int64(), ShouldEqual, 900)
+		So(cc1m2.AmountOf(ld2).Int64(), ShouldEqual, 2000)
+	})
+
+	Convey("test coin denom", t, func() {
+		cc1 := coin.NewInt64Coin(ld1, 1000)
+		cc1s := coin.Coins{cc1}
+		So(cc1.Denom, ShouldEqual, ld1)
+		So(cc1s.AmountOf(ld1).Int64(), ShouldEqual, 1000)
+	})
+
+}

--- a/test/simapp/test_helpers.go
+++ b/test/simapp/test_helpers.go
@@ -193,7 +193,7 @@ func GenSequenceOfTxs(payer types.AccountID, msgs []sdk.Msg, accNums []uint64, i
 	for i := 0; i < numToGenerate; i++ {
 		txs[i] = helpers.GenTx(
 			msgs,
-			types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 200000)},
+			types.NewInt64Coins(constants.DefaultBondDenom, 200000),
 			helpers.DefaultGenTxGas,
 			payer,
 			"",

--- a/test/simapp/test_tx.go
+++ b/test/simapp/test_tx.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	DefaultTestFee = types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 100000)}
+	DefaultTestFee = types.NewInt64Coins(constants.DefaultBondDenom, 100000)
 )
 
 type TestTx struct {

--- a/test/simulation/rand_util.go
+++ b/test/simulation/rand_util.go
@@ -104,7 +104,7 @@ func RandSubsetCoins(r *rand.Rand, coins types.Coins) types.Coins {
 	if err != nil {
 		return types.Coins{}
 	}
-	subset := types.Coins{types.NewCoin(coin.Denom, amt)}
+	subset := types.NewCoins(types.NewCoin(coin.Denom, amt))
 	for i, c := range coins {
 		// skip denom that we already chose earlier
 		if i == denomIdx {

--- a/x/account/handler_test.go
+++ b/x/account/handler_test.go
@@ -51,7 +51,7 @@ func TestCreateNormalAccount(t *testing.T) {
 				constants.SystemAccountID,
 				name1,
 				addr1)
-			fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 100000)}
+			fee := types.NewInt64Coins(constants.DefaultBondDenom, 100000)
 
 			header := abci.Header{Height: app.LastBlockHeight() + 1}
 			_, _, err := simapp.SignCheckDeliver(
@@ -93,7 +93,7 @@ func testAccountCreate(
 	creator types.AccountID, name types.Name, auth types.AccAddress) error {
 	ctxCheck := app.BaseApp.NewContext(true, abci.Header{Height: app.LastBlockHeight() + 1})
 	creatorAuth := app.AccountKeeper().GetAccount(ctxCheck, creator).GetAuth()
-	fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 100000)}
+	fee := types.NewInt64Coins(constants.DefaultBondDenom, 100000)
 	msg := accountTypes.NewMsgCreateAccount(
 		creatorAuth,
 		creator,
@@ -114,8 +114,7 @@ func testAccountCreate(
 }
 
 func TestCreateAccountNameCheck(t *testing.T) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 	genAcc := simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1)
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(), genAcc)
 	app := simapp.SetupWithGenesisAccounts(genAccs)
@@ -154,8 +153,7 @@ func TestCreateAccountNameCheck(t *testing.T) {
 }
 
 func TestCreateAccountDoubleTimes(t *testing.T) {
-	assets := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	assets := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 	genAccs := simapp.NewGenesisAccounts(
 		wallet.GetRootAuth(),
 		simapp.NewSimGenesisAccount(account1, addr1).WithAsset(assets),
@@ -178,8 +176,7 @@ func TestCreateAccountDoubleTimes(t *testing.T) {
 }
 
 func TestUpdateAccountAuth(t *testing.T) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 	genAcc := simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1)
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(), genAcc)
 	app := simapp.SetupWithGenesisAccounts(genAccs)
@@ -195,7 +192,7 @@ func TestUpdateAccountAuth(t *testing.T) {
 			addr1,
 			name1,
 			newAuth)
-		fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 100000)}
+		fee := types.NewInt64Coins(constants.DefaultBondDenom, 100000)
 
 		header := abci.Header{Height: app.LastBlockHeight() + 1}
 		_, _, err = simapp.SignCheckDeliver(
@@ -230,8 +227,7 @@ func TestUpdateAccountAuth(t *testing.T) {
 }
 
 func TestUpdateAccountAuthErrReturn(t *testing.T) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 	genAcc := simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1)
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(), genAcc)
 	app := simapp.SetupWithGenesisAccounts(genAccs)
@@ -247,7 +243,7 @@ func TestUpdateAccountAuthErrReturn(t *testing.T) {
 			addr1,
 			types.MustName("noexitaccount"),
 			newAuth)
-		fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 100000)}
+		fee := types.NewInt64Coins(constants.DefaultBondDenom, 100000)
 
 		header := abci.Header{Height: app.LastBlockHeight() + 1}
 		_, _, err = simapp.SignCheckDeliver(
@@ -296,8 +292,7 @@ func checkAuthSequenceByQuery(app *simapp.SimApp, ctx sdk.Context, addr types.Ac
 }
 
 func TestAuthIsNoWithAccount(t *testing.T) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 	genAcc := simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1)
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(), genAcc)
 	app := simapp.SetupWithGenesisAccounts(genAccs)
@@ -324,7 +319,7 @@ func TestAuthIsNoWithAccount(t *testing.T) {
 			addr1,
 			name1,
 			addr)
-		fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 100000)}
+		fee := types.NewInt64Coins(constants.DefaultBondDenom, 100000)
 
 		header := abci.Header{Height: app.LastBlockHeight() + 1}
 		_, _, err = simapp.SignCheckDeliver(
@@ -342,8 +337,7 @@ func TestAuthIsNoWithAccount(t *testing.T) {
 }
 
 func TestAuthForTwoAccount(t *testing.T) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(),
 		simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1),

--- a/x/account/keeper/account_test.go
+++ b/x/account/keeper/account_test.go
@@ -71,8 +71,7 @@ func TestEnsureAccount(t *testing.T) {
 }
 
 func TestIterateAccount(t *testing.T) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 	genAcc1 := simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1)
 	genAcc2 := simapp.NewSimGenesisAccount(account2, addr1).WithAsset(asset1)
 	genAcc3 := simapp.NewSimGenesisAccount(types.NewAccountIDFromAccAdd(addr1), addr1).WithAsset(asset1)
@@ -123,8 +122,7 @@ func TestIterateAccount(t *testing.T) {
 }
 
 func TestAccountExist(t *testing.T) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 	genAcc1 := simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1)
 	genAcc2 := simapp.NewSimGenesisAccount(account2, addr1).WithAsset(asset1)
 	genAcc3 := simapp.NewSimGenesisAccount(types.NewAccountIDFromAccAdd(addr1), addr1).WithAsset(asset1)

--- a/x/account/keeper/keeper_test.go
+++ b/x/account/keeper/keeper_test.go
@@ -28,8 +28,7 @@ var (
 )
 
 func createTestApp() (*simapp.SimApp, sdk.Context) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 	genAcc := simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1)
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(), genAcc)
 	app := simapp.SetupWithGenesisAccounts(genAccs)

--- a/x/account/keeper/querier_test.go
+++ b/x/account/keeper/querier_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestQueryAccount(t *testing.T) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 	genAcc1 := simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1)
 	genAcc2 := simapp.NewSimGenesisAccount(types.NewAccountIDFromAccAdd(addr2), addr2).WithAsset(asset1)
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(), genAcc1, genAcc2)
@@ -156,8 +155,7 @@ func TestQueryAccount(t *testing.T) {
 }
 
 func TestQueryAuth(t *testing.T) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 	genAcc1 := simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1)
 	genAcc2 := simapp.NewSimGenesisAccount(types.NewAccountIDFromAccAdd(addr2), addr2).WithAsset(asset1)
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(), genAcc1, genAcc2)
@@ -250,8 +248,7 @@ func TestQueryAuth(t *testing.T) {
 }
 
 func TestQueryAccountsByAuth(t *testing.T) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(),
 		simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1),

--- a/x/asset/handler_test.go
+++ b/x/asset/handler_test.go
@@ -37,14 +37,14 @@ var (
 )
 
 func createAppForTest() (*simapp.SimApp, sdk.Context) {
-	asset1 := types.Coins{
+	asset1 := types.NewCoins(
 		types.NewInt64Coin("foo/coin", 10000000),
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
-	asset2 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
-	asset3 := types.Coins{
+		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000))
+	asset2 := types.NewCoins(
+		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000))
+	asset3 := types.NewCoins(
 		types.NewInt64Coin("foo/coin", 100),
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000))
 
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(),
 		simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1),
@@ -135,9 +135,9 @@ func issueCoin(t *testing.T, app *simapp.SimApp, isSuccess bool,
 
 func TestSendAddressNotEnoughBalance(t *testing.T) {
 	Convey("TestSendAddressNotEnoughBalance", t, func() {
-		asset1 := types.Coins{
+		asset1 := types.NewCoins(
 			types.NewInt64Coin("foo/coin", 67),
-			types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+			types.NewInt64Coin(constants.DefaultBondDenom, 10000000000))
 		genAcc := simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1)
 
 		genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(), genAcc)
@@ -156,8 +156,8 @@ func TestSendAddressNotEnoughBalance(t *testing.T) {
 
 		ctxCheck.Logger().Info("auth nums", "seq", origAuthSeq, "num", origAuthNum)
 
-		msg := assetTypes.NewMsgTransfer(addr1, account1, addAccount1, types.Coins{types.NewInt64Coin("foo/coin", 100)})
-		fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 100000)}
+		msg := assetTypes.NewMsgTransfer(addr1, account1, addAccount1, types.NewInt64Coins("foo/coin", 100))
+		fee := types.NewInt64Coins(constants.DefaultBondDenom, 100000)
 
 		header := abci.Header{Height: app.LastBlockHeight() + 1}
 		_, _, err = simapp.SignCheckDeliver(t, app.Codec(), app.BaseApp,
@@ -462,7 +462,7 @@ func TestLockCoins(t *testing.T) {
 	Convey("test lock core coins", t, func() {
 		ctx := app.NewTestContext()
 
-		lockedCoins := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 1000000000)}
+		lockedCoins := types.NewInt64Coins(constants.DefaultBondDenom, 1000000000)
 		lockedBlockNum := app.LastBlockHeight() + 1 + 5
 
 		msgLock := assetTypes.NewMsgLockCoin(addr4, account4, lockedCoins, lockedBlockNum)
@@ -492,7 +492,7 @@ func TestLockCoins(t *testing.T) {
 		currCoinsBeforeFailedTransferCoins := app.AssetKeeper().GetAllBalances(app.NewTestContext(), account4)
 
 		// when locked, coins cannot be transfer
-		err = transfer(t, app, false, account4, account1, types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 100)}, account4)
+		err = transfer(t, app, false, account4, account1, types.NewInt64Coins(constants.DefaultBondDenom, 100), account4)
 		So(err, simapp.ShouldErrIs, assetTypes.ErrAssetCoinsLocked)
 
 		currCoins = app.AssetKeeper().GetAllBalances(app.NewTestContext(), account4)
@@ -513,7 +513,7 @@ func TestLockCoins(t *testing.T) {
 
 		var (
 			ctx            = app.NewTestContext()
-			lockedCoins    = types.Coins{types.NewInt64Coin(denom, 100)}
+			lockedCoins    = types.NewInt64Coins(denom, 100)
 			lockedBlockNum = app.LastBlockHeight() + 1 + 5
 		)
 
@@ -535,7 +535,7 @@ func TestLockCoins(t *testing.T) {
 
 		// lock many coins
 		var (
-			lockedCoins2    = types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 100)}
+			lockedCoins2    = types.NewInt64Coins(constants.DefaultBondDenom, 100)
 			lockedBlockNum2 = app.LastBlockHeight() + 100
 		)
 
@@ -576,7 +576,7 @@ func TestLockCoinsError(t *testing.T) {
 		So(issueCoin(t, app, true, account2, symbol, issueAmt), ShouldBeNil)
 
 		msgLock := assetTypes.NewMsgLockCoin(
-			addr2, account2, types.Coins{types.NewInt64Coin("aaa/coin", 100)}, 10)
+			addr2, account2, types.NewInt64Coins("aaa/coin", 100), 10)
 		tx := simapp.NewTxForTest(
 			account2,
 			[]sdk.Msg{
@@ -599,7 +599,7 @@ func TestLockCoinsError(t *testing.T) {
 		// no issue, so account2 no have this coin
 
 		msgLock := assetTypes.NewMsgLockCoin(
-			addr2, account2, types.Coins{types.NewInt64Coin(denom, 100)}, 10)
+			addr2, account2, types.NewInt64Coins(denom, 100), 10)
 		tx := simapp.NewTxForTest(
 			account2,
 			[]sdk.Msg{
@@ -625,7 +625,7 @@ func TestLockCoinsError(t *testing.T) {
 		simapp.AfterBlockCommitted(app, 2)
 
 		msgLock := assetTypes.NewMsgLockCoin(
-			addr2, account2, types.Coins{types.NewInt64Coin(denom, 100)}, 2) // 2 has already passed
+			addr2, account2, types.NewInt64Coins(denom, 100), 2) // 2 has already passed
 		tx := simapp.NewTxForTest(
 			account2,
 			[]sdk.Msg{
@@ -652,7 +652,7 @@ func TestLockCoinsError(t *testing.T) {
 		So(issueCoin(t, app, true, account2, symbol, lockAmt), ShouldBeNil)
 
 		msgLock := assetTypes.NewMsgLockCoin(
-			addr2, account2, types.Coins{types.NewInt64Coin(denom, 100)}, 100) // 2 has already passed
+			addr2, account2, types.NewInt64Coins(denom, 100), 100) // 2 has already passed
 		tx := simapp.NewTxForTest(
 			account2,
 			[]sdk.Msg{
@@ -663,7 +663,7 @@ func TestLockCoinsError(t *testing.T) {
 			simapp.ShouldErrIs, assetTypes.ErrAssetCoinCannotBeLock)
 
 		// for multiple coins test
-		locks := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 10)}.Add(lockAmt)
+		locks := types.NewInt64Coins(constants.DefaultBondDenom, 10).Add(lockAmt)
 		msgLock2 := assetTypes.NewMsgLockCoin(addr2, account2, locks, 100)
 		tx2 := simapp.NewTxForTest(
 			account2,

--- a/x/asset/keeper/keeper.go
+++ b/x/asset/keeper/keeper.go
@@ -135,12 +135,12 @@ func (a AssetKeeper) Burn(ctx sdk.Context, id types.AccountID, amount types.Coin
 		return sdkerrors.Wrap(err, "burn get coins")
 	}
 
-	newCoins, isNegative := coins.SafeSub(types.Coins{amount})
+	newCoins, isNegative := coins.SafeSub(NewCoins(amount))
 	if isNegative {
 		return sdkerrors.Wrap(types.ErrAssetCoinNoEnough, "burn coins error")
 	}
 
-	if err := a.checkIsCanUseCoins(ctx, id, types.Coins{amount}, coins); err != nil {
+	if err := a.checkIsCanUseCoins(ctx, id, NewCoins(amount), coins); err != nil {
 		return sdkerrors.Wrap(err, "burn")
 	}
 

--- a/x/asset/keeper/keeper_power.go
+++ b/x/asset/keeper/keeper_power.go
@@ -61,7 +61,7 @@ func (a AssetKeeper) subCoinPower(ctx sdk.Context, id types.AccountID, amt Coins
 	}
 
 	if subed == nil {
-		subed = Coins{NewInt64Coin(amt[0].Denom, 0)}
+		subed = NewInt64Coins(amt[0].Denom, 0)
 	}
 
 	if err := a.setCoinsPower(ctx, id, subed); err != nil {

--- a/x/asset/keeper/keeper_test.go
+++ b/x/asset/keeper/keeper_test.go
@@ -28,8 +28,7 @@ var (
 )
 
 func createTestApp() (*simapp.SimApp, sdk.Context) {
-	asset1 := types.Coins{
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)}
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
 
 	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(),
 		simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1),
@@ -48,8 +47,7 @@ func TestAssetTransfer(t *testing.T) {
 	app, ctx := createTestApp()
 
 	Convey("test transfer in keeper", t, func() {
-		amt := types.Coins{
-			types.NewInt64Coin(constants.DefaultBondDenom, 100)}
+		amt := types.NewInt64Coins(constants.DefaultBondDenom, 100)
 		addr := wallet.NewAccAddress()
 		err := app.AssetKeeper().Transfer(ctx, account1, types.NewAccountIDFromAccAdd(addr), amt)
 		So(err, ShouldBeNil)

--- a/x/asset/keeper/types.go
+++ b/x/asset/keeper/types.go
@@ -22,6 +22,8 @@ type (
 )
 
 var (
-	NewDec       = types.NewDec
-	NewInt64Coin = types.NewInt64Coin
+	NewDec        = types.NewDec
+	NewCoins      = types.NewCoins
+	NewInt64Coin  = types.NewInt64Coin
+	NewInt64Coins = types.NewInt64Coins
 )

--- a/x/staking/handler_test.go
+++ b/x/staking/handler_test.go
@@ -9,13 +9,14 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 
+	"encoding/hex"
+
 	"github.com/KuChainNetwork/kuchain/chain/config"
 	"github.com/KuChainNetwork/kuchain/chain/constants"
 	"github.com/KuChainNetwork/kuchain/chain/types"
 	"github.com/KuChainNetwork/kuchain/test/simapp"
 	stakingTypes "github.com/KuChainNetwork/kuchain/x/staking/types"
 	"github.com/tendermint/tendermint/crypto"
-	"encoding/hex"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
@@ -33,13 +34,11 @@ func newTestApp(wallet *simapp.Wallet) (addAlice, addJack, addValidator sdk.AccA
 		resInt = sdk.NewInt(10000000000000000)
 	}
 	initAsset := types.NewCoin(constants.DefaultBondDenom, resInt)
-	asset1 := types.Coins{
-		types.NewInt64Coin("foo/coin", 67),
-		initAsset}
+	asset1 := types.NewCoins(types.NewInt64Coin("foo/coin", 67), initAsset)
 
-	asset2 := types.Coins{
+	asset2 := types.NewCoins(
 		types.NewInt64Coin("foo/coin", 67),
-		types.NewInt64Coin(constants.DefaultBondDenom, 10000000)}
+		types.NewInt64Coin(constants.DefaultBondDenom, 10000000))
 
 	genAlice := simapp.NewSimGenesisAccount(accAlice, addAlice).WithAsset(asset1)
 	genJack := simapp.NewSimGenesisAccount(accJack, addJack).WithAsset(asset1)
@@ -100,7 +99,7 @@ func exitValidator(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp, addA
 	So(err, ShouldBeNil)
 	description := stakingTypes.NewDescription("Newmoniker", "Newidentity", "Newwebsite", "NewsecurityContact", "Newdetails")
 	msg := stakingTypes.NewKuMsgEditValidator(addAlice, accAlice, description, &rate)
-	fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 1000000)}
+	fee := types.NewInt64Coins(constants.DefaultBondDenom, 1000000)
 	header := abci.Header{Height: app.LastBlockHeight() + 1}
 	_, _, err = simapp.SignCheckDeliver(t, app.Codec(), app.BaseApp,
 		header, accAlice, fee,
@@ -116,7 +115,7 @@ func delegationValidator(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp
 	origAuthSeq, origAuthNum, err := app.AccountKeeper().GetAuthSequence(ctxCheck, addAlice)
 	So(err, ShouldBeNil)
 	msg := stakingTypes.NewKuMsgDelegate(addAlice, accAlice, accValidator, amount)
-	fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 1000000)}
+	fee := types.NewInt64Coins(constants.DefaultBondDenom, 1000000)
 	header := abci.Header{Height: app.LastBlockHeight() + 1}
 	_, _, err = simapp.SignCheckDeliver(t, app.Codec(), app.BaseApp,
 		header, accAlice, fee,

--- a/x/supply/keeper/account_test.go
+++ b/x/supply/keeper/account_test.go
@@ -2,18 +2,14 @@ package keeper_test
 
 import (
 	"encoding/json"
-	"strings"
-
-	//"fmt"
 	chainType "github.com/KuChainNetwork/kuchain/chain/types"
 	"github.com/KuChainNetwork/kuchain/x/supply/exported"
 	"github.com/KuChainNetwork/kuchain/x/supply/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	//authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
-	//authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
+	"gopkg.in/yaml.v2"
+	"strings"
 	"testing"
 )
 
@@ -32,7 +28,7 @@ func TestModuleAccountMarshalYAML(t *testing.T) {
 	bs, err := yaml.Marshal(moduleAcc)
 	require.NoError(t, err)
 
-	want:="account_number: 0\naddress: cosmos1vdhhxmt0wvcns7psvakhwmn209cnzuthn4xfwn\nname: test\npermissions:\n- minter\n- burner\n- staking\npublic_key: \"\"\n"
+	want := "account_number: 0\naddress: cosmos1vdhhxmt0wvcns7psvakhwmn209cnzuthn4xfwn\nname: test\npermissions:\n- minter\n- burner\n- staking\npublic_key: \"\"\n"
 
 	require.Equal(t, want, string(bs))
 }
@@ -99,9 +95,9 @@ func TestModuleAccountJSON(t *testing.T) {
 	bz, err := json.Marshal(mAccI)
 	require.NoError(t, err)
 
-	require.NotEqual(t, strings.Index(string(bz),mAccI.GetAddress().String()),-1)
-	require.NotEqual(t, strings.Index(string(bz),mAccI.GetID().String()),-1)
-	require.NotEqual(t, strings.Index(string(bz),mAccI.GetPermissions()[0]),-1)
+	require.NotEqual(t, strings.Index(string(bz), mAccI.GetAddress().String()), -1)
+	require.NotEqual(t, strings.Index(string(bz), mAccI.GetID().String()), -1)
+	require.NotEqual(t, strings.Index(string(bz), mAccI.GetPermissions()[0]), -1)
 
 	var a types.ModuleAccount
 	require.NoError(t, json.Unmarshal(bz, &a))


### PR DESCRIPTION
For Coins Types, some func dep the coins list is sorted, In Testcase, some code just create a coins by types:

```go
testCoins := types.Coins{xxx1, xxx2}
```

This will make `testCoins` no sorted, if we change the chain symbol, it will make the test failed.

Also fix some testcase failed by other problem:

- Add a func to create coins.
- Del wrong "github.com/ghodss/yaml" import in a test.
