### PR TITLE
Fix test failed in supply account_test.go and bank_test.go

### DIFF
--- a/x/supply/keeper/account_test.go
+++ b/x/supply/keeper/account_test.go
@@ -28,7 +28,7 @@ func TestModuleAccountMarshalYAML(t *testing.T) {
 	bs, err := yaml.Marshal(moduleAcc)
 	require.NoError(t, err)
 
-	want := "account_number: 0\naddress: cosmos1vdhhxmt0wvcns7psvakhwmn209cnzuthn4xfwn\nname: test\npermissions:\n- minter\n- burner\n- staking\npublic_key: \"\"\n"
+	want := "|\n  address: cosmos1vdhhxmt0wvcns7psvakhwmn209cnzuthn4xfwn\n  public_key: \"\"\n  account_number: 0\n  name: test\n  permissions:\n  - minter\n  - burner\n  - staking\n"
 
 	require.Equal(t, want, string(bs))
 }

--- a/x/supply/keeper/bank_test.go
+++ b/x/supply/keeper/bank_test.go
@@ -121,7 +121,7 @@ func TestSendCoins(t *testing.T) {
 
 	holderAccCoins := getCoinsByName(ctx, *app.SupplyKeeper(), holderAcc.GetName().String(), *app.AssetKeeper())
 	fmt.Println(holderAccCoins.String())
-	require.Equal(t, chainType.Coins{chainType.NewCoin(constants.DefaultBondDenom, chainType.NewInt(0))}, holderAccCoins)
+	require.Equal(t, chainType.Coins{}, holderAccCoins)
 
 	BurnerAccCoins := getCoinsByName(ctx, *app.SupplyKeeper(), types.Burner, *app.AssetKeeper())
 	require.Equal(t, initCoins, BurnerAccCoins)
@@ -129,7 +129,7 @@ func TestSendCoins(t *testing.T) {
 	err = app.SupplyKeeper().SendCoinsFromModuleToAccount(ctx, types.Burner, bAcc, initCoins)
 	require.NoError(t, err)
 	BurnerAccCoins = getCoinsByName(ctx, *app.SupplyKeeper(), types.Burner, *app.AssetKeeper())
-	require.Equal(t, chainType.Coins{chainType.NewCoin(constants.DefaultBondDenom, chainType.NewInt(0))}, BurnerAccCoins)
+	require.Equal(t, chainType.Coins{}, BurnerAccCoins)
 
 	BAccCoins := app.AssetKeeper().GetCoinPowers(ctx, baseAcc.GetID())
 	require.Equal(t, chainType.NewCoins(chainType.NewCoin(constants.DefaultBondDenom, initTokens.Mul(sdk.NewInt(3)))), BAccCoins)
@@ -242,7 +242,7 @@ func TestBurnCoins(t *testing.T) {
 	require.NoError(t, err)
 
 	bAccCoins = getCoinsByName(ctx, keeper, types.Burner, *app.AssetKeeper())
-	require.Equal(t, chainType.Coins{chainType.NewCoin(constants.DefaultBondDenom, sdk.NewInt(0))}, bAccCoins)
+	require.Equal(t, chainType.Coins{}, bAccCoins)
 	require.Equal(t, chainType.Coins{chainType.NewCoin(constants.DefaultBondDenom, sdk.NewInt(200000000))}, keeper.GetSupply(ctx).GetTotal())
 
 	// test same functionality on module account with multiple permissions
@@ -256,6 +256,6 @@ func TestBurnCoins(t *testing.T) {
 	require.NoError(t, err)
 
 	multiPermAccCoins := getCoinsByName(ctx, keeper, multiPermAcc.GetName().String(), *app.AssetKeeper())
-	require.Equal(t, chainType.Coins{chainType.NewCoin(constants.DefaultBondDenom, sdk.NewInt(0))}, multiPermAccCoins)
+	require.Equal(t, chainType.Coins{}, multiPermAccCoins)
 	require.Equal(t, chainType.Coins{chainType.NewCoin(constants.DefaultBondDenom, sdk.NewInt(300000000))}, keeper.GetSupply(ctx).GetTotal())
 }


### PR DESCRIPTION
## Summary

In test, if coins is empty, so we should compare with `coin{}`:

```
require.Equal(t, xxxCoins, chainType.Coins{})
```

as Coins will del the coin which amount is zero.