### PR TITLE
Add MsgTransfer msg type for default msg to transfer token in kuchain

### DIFF
--- a/chain/msg/handler.go
+++ b/chain/msg/handler.go
@@ -52,6 +52,11 @@ func onHandlerKuMsg(ctx Context, k AssetTransfer, msg KuTransfMsg) error {
 		return nil
 	}
 
+	// check validate for safe
+	if err := msg.ValidateBasic(); err != nil {
+		return err
+	}
+
 	ctx.RequireAuth(msg.GetFrom())
 
 	if err := k.Transfer(ctx.Context(), from, to, amount); err != nil {

--- a/chain/types/interfaces.go
+++ b/chain/types/interfaces.go
@@ -5,6 +5,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+type (
+	Msg = sdk.Msg
+)
+
 // AssetTransfer a interface for asset coins transfer
 type AssetTransfer interface {
 	Transfer(ctx sdk.Context, from, to AccountID, amount Coins) error

--- a/x/asset/handler.go
+++ b/x/asset/handler.go
@@ -17,7 +17,9 @@ func NewHandler(k keeper.AssetCoinsKeeper) msg.Handler {
 	return func(ctx chainTypes.Context, msg sdk.Msg) (*sdk.Result, error) {
 		switch msg := msg.(type) {
 		case *types.KuMsg:
-			return handleMsgTransfer(ctx)
+			return handleKuMsg(ctx)
+		case *types.MsgTransfer:
+			return handleMsgTransfer(ctx, k, msg)
 		case *types.MsgCreateCoin:
 			return handleMsgCreate(ctx, k, msg)
 		case *types.MsgIssueCoin:
@@ -34,8 +36,14 @@ func NewHandler(k keeper.AssetCoinsKeeper) msg.Handler {
 	}
 }
 
-// handleMsgTransfer Handle KuMsg for transfer.
-func handleMsgTransfer(ctx chainTypes.Context) (*sdk.Result, error) {
+// handleKuMsg Handle KuMsg.
+func handleKuMsg(ctx chainTypes.Context) (*sdk.Result, error) {
+	// no need process transfer
+	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
+}
+
+// handleMsgTransfer Handle for transfer.
+func handleMsgTransfer(ctx chainTypes.Context, k keeper.AssetCoinsKeeper, msg *types.MsgTransfer) (*sdk.Result, error) {
 	// no need process transfer
 	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
 }

--- a/x/asset/transfer_test.go
+++ b/x/asset/transfer_test.go
@@ -1,0 +1,78 @@
+package asset_test
+
+import (
+	"testing"
+
+	"github.com/KuChainNetwork/kuchain/chain/constants"
+	"github.com/KuChainNetwork/kuchain/chain/types"
+	"github.com/KuChainNetwork/kuchain/test/simapp"
+	assetTypes "github.com/KuChainNetwork/kuchain/x/asset/types"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestTransferCoins(t *testing.T) {
+	app, _ := createAppForTest()
+	Convey("test normal transfer", t, func() {
+		ctx := app.NewTestContext()
+		acc1Coins := app.AssetKeeper().GetAllBalances(ctx, account1)
+		acc2Coins := app.AssetKeeper().GetAllBalances(ctx, account2)
+		coins2Transfer := types.NewInt64Coins(constants.DefaultBondDenom, 1000)
+
+		So(transfer(t, app, true, account1, account2, coins2Transfer, account1), ShouldBeNil)
+		amt := acc1Coins.Sub(simapp.DefaultTestFee)
+		ctx = app.NewTestContext()
+		So(amt.Sub(coins2Transfer), simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account1))
+		So(acc2Coins.Add(coins2Transfer...), simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account2))
+	})
+}
+
+func TestTransferCoinsErr(t *testing.T) {
+	app, _ := createAppForTest()
+	Convey("test transfer negative coins", t, func() {
+		ctx := app.NewTestContext()
+		acc1Coins := app.AssetKeeper().GetAllBalances(ctx, account1)
+		acc2Coins := app.AssetKeeper().GetAllBalances(ctx, account2)
+		coins2Transfer := types.Coins{types.Coin{constants.DefaultBondDenom, types.NewInt(-1000)}}
+
+		So(transfer(t, app, false, account1, account2, coins2Transfer, account1),
+			simapp.ShouldErrIs, types.ErrTransfNoEnough)
+
+		amt := acc1Coins
+		//amt := acc1Coins.Sub(simapp.DefaultTestFee) will err by basic check
+
+		ctx = app.NewTestContext()
+		So(amt, simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account1))
+		So(acc2Coins, simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account2))
+	})
+
+	Convey("test transfer no enough coins", t, func() {
+		ctx := app.NewTestContext()
+		acc1Coins := app.AssetKeeper().GetAllBalances(ctx, account1)
+		acc2Coins := app.AssetKeeper().GetAllBalances(ctx, account2)
+		coins2Transfer := types.Coins{types.Coin{constants.DefaultBondDenom, types.NewInt(10000000001)}}
+
+		So(transfer(t, app, false, account1, account2, coins2Transfer, account1),
+			simapp.ShouldErrIs, assetTypes.ErrAssetCoinNoEnough)
+
+		amt := acc1Coins.Sub(simapp.DefaultTestFee)
+
+		ctx = app.NewTestContext()
+		So(amt, simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account1))
+		So(acc2Coins, simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account2))
+	})
+
+	Convey("test transfer empty account", t, func() {
+		ctx := app.NewTestContext()
+		acc1Coins := app.AssetKeeper().GetAllBalances(ctx, account1)
+		acc2Coins := app.AssetKeeper().GetAllBalances(ctx, account2)
+		coins2Transfer := types.Coins{types.Coin{constants.DefaultBondDenom, types.NewInt(10000000001)}}
+
+		So(transfer(t, app, true, account1, types.AccountID{}, coins2Transfer, account1), ShouldBeNil)
+
+		amt := acc1Coins.Sub(simapp.DefaultTestFee)
+
+		ctx = app.NewTestContext()
+		So(amt, simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account1))
+		So(acc2Coins, simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account2))
+	})
+}

--- a/x/asset/types/codec.go
+++ b/x/asset/types/codec.go
@@ -17,6 +17,7 @@ func RegisterCodec(cdc *codec.Codec) {
 
 	cdc.RegisterConcrete(&KuMsg{}, "kuchain/msg", nil)
 
+	cdc.RegisterConcrete(&MsgTransfer{}, "asset/transfer", nil)
 	cdc.RegisterConcrete(&MsgCreateCoinData{}, "asset/createData", nil)
 	cdc.RegisterConcrete(&MsgCreateCoin{}, "asset/create", nil)
 	cdc.RegisterConcrete(&MsgIssueCoinData{}, "asset/issueData", nil)

--- a/x/asset/types/msgs.go
+++ b/x/asset/types/msgs.go
@@ -12,21 +12,36 @@ import (
 const RouterKey = ModuleName
 
 var (
-	RouterKeyName                 = types.MustName(RouterKey)
-	_, _, _, _, _ types.KuMsgData = (*MsgCreateCoinData)(nil), (*MsgIssueCoinData)(nil), (*MsgBurnCoinData)(nil), (*MsgLockCoinData)(nil), (*MsgUnlockCoinData)(nil)
+	RouterKeyName                    = types.MustName(RouterKey)
+	_, _, _, _, _    types.KuMsgData = (*MsgCreateCoinData)(nil), (*MsgIssueCoinData)(nil), (*MsgBurnCoinData)(nil), (*MsgLockCoinData)(nil), (*MsgUnlockCoinData)(nil)
+	_, _, _, _, _, _ types.Msg       = (*MsgTransfer)(nil), (*MsgCreateCoin)(nil), (*MsgIssueCoin)(nil), (*MsgBurnCoin)(nil), (*MsgLockCoin)(nil), (*MsgUnlockCoin)(nil)
 )
 
 type (
 	KuMsg = types.KuMsg
 )
 
+type MsgTransfer struct {
+	types.KuMsg
+}
+
 // NewMsgTransfer create msg transfer
-func NewMsgTransfer(auth types.AccAddress, from types.AccountID, to types.AccountID, amount Coins) KuMsg {
-	return *msg.MustNewKuMsg(
-		RouterKeyName,
-		msg.WithAuth(auth),
-		msg.WithTransfer(from, to, amount),
-	)
+func NewMsgTransfer(auth types.AccAddress, from types.AccountID, to types.AccountID, amount Coins) MsgTransfer {
+	return MsgTransfer{
+		*msg.MustNewKuMsg(
+			RouterKeyName,
+			msg.WithAuth(auth),
+			msg.WithTransfer(from, to, amount),
+		),
+	}
+}
+
+func (msg MsgTransfer) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateBasic(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type MsgCreateCoin struct {


### PR DESCRIPTION
## Summary

Add `MsgTransfer` msg to transfer tokens.

## Introduction

In Kuchain, we use `KuMsg` to the base msg type, every msg in kuchain is a `KuMsg`.
`KuMsg` contain a transfer for tokens, so a just transfer msg for now is just to push a `KuMsg` to chain.
We add a `MsgTransfer` to process just a transfer msg, also user can commit a KuMsg to chain.

In Next Versions, we need to change `KuMsg` to delete its default `ValidateBasic` func, so if a msg contain `KuMsg` and not imp its `ValidateBasic`, so it will build failed.

## Action And Data

Now the `KuMsg` 's `Action` value is not check in most case, in future, some msg will use action to select data processer.

`MsgTransfer` will make a diff between a simple `KuMsg` as the `KuMsg` will desgined to use more action types.