### PR TITLE
Fix Asset Create Error By Check Current Height

### DIFF
--- a/x/asset/issue_test.go
+++ b/x/asset/issue_test.go
@@ -1,0 +1,27 @@
+package asset_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/KuChainNetwork/kuchain/chain/types"
+)
+
+func TestCreateAssetOpt(t *testing.T) {
+	app, _ := createAppForTest()
+
+	Convey("test create asset issue to height", t, func() {
+		var (
+			se         = types.MustName("abc")
+			demon      = types.CoinDenom(name4, se) // creator has @
+			maxSupply  = types.Coin{demon, types.NewInt(10000000000000)}
+			initSupply = types.Coin{demon, types.NewInt(0)}
+			desc       = []byte(fmt.Sprintf("desc for %s", demon))
+		)
+
+		So(createCoinExt(t, app, true, account4, se, maxSupply, true, true, 1000, initSupply, desc), ShouldBeNil)
+	})
+
+}

--- a/x/asset/types/msgs.go
+++ b/x/asset/types/msgs.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"math"
-
 	"github.com/KuChainNetwork/kuchain/chain/msg"
 	"github.com/KuChainNetwork/kuchain/chain/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -106,7 +104,7 @@ func (msg MsgCreateCoin) ValidateBasic() error {
 	}
 
 	if err := CheckCoinStatOpts(
-		math.MaxInt64, // no check this
+		0, // no check this
 		data.CanIssue, data.CanLock,
 		data.IssueToHeight,
 		data.InitSupply, data.MaxSupply); err != nil {


### PR DESCRIPTION
## Summary

Fix asset create error by current height value in check func.

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes