### PR TITLE
check kumsg transfer amount and data amount

### DIFF
--- a/chain/types/errors.go
+++ b/chain/types/errors.go
@@ -40,6 +40,7 @@ var (
 	ErrKuMsgDataSameAccount    = sdkerrors.Register(KuCodeSpace, errorCode(kuMsgErrorCodeRoot, 9), "KuMsg msg same account error")
 	ErrKuMsgDataNotFindAccount = sdkerrors.Register(KuCodeSpace, errorCode(kuMsgErrorCodeRoot, 10), "KuMsg msg can not find account error")
 	ErrKuMsgAccountIDNil       = sdkerrors.Register(KuCodeSpace, errorCode(kuMsgErrorCodeRoot, 11), "KuMsg msg account id should not be nil")
+	ErrKuMsgInconsistentAmount = sdkerrors.Register(KuCodeSpace, errorCode(kuMsgErrorCodeRoot, 12), "KuMsg msg amount and data amount are inconsistent")
 )
 
 var (

--- a/x/gov/handle_test.go
+++ b/x/gov/handle_test.go
@@ -128,7 +128,6 @@ func submitProposal(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp, add
 
 	origAuthSeq, origAuthNum, err := app.AccountKeeper().GetAuthSequence(ctxCheck, addAlice)
 	So(err, ShouldBeNil)
-	//NewKuMsgSubmitProposal(auth sdk.AccAddress, content Content, initialDeposit Coins, proposer AccountID)
 	msg := customizeKuMsgProposal(addAlice, content, amount, transferAmount, accAlice)
 	fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 1000000)}
 	header := abci.Header{Height: app.LastBlockHeight() + 1}
@@ -146,7 +145,6 @@ func vote(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp, addAlice sdk.
 
 	origAuthSeq, origAuthNum, err := app.AccountKeeper().GetAuthSequence(ctxCheck, addAlice)
 	So(err, ShouldBeNil)
-	//NewKuMsgVote(auth sdk.AccAddress, voter AccountID, proposalID uint64, option VoteOption)
 	msg := govTypes.NewKuMsgVote(addAlice, accAlice, proposalID, voteOption)
 	fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 1000000)}
 	header := abci.Header{Height: app.LastBlockHeight() + 1}
@@ -189,7 +187,6 @@ func disposit(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp, addAlice 
 
 	origAuthSeq, origAuthNum, err := app.AccountKeeper().GetAuthSequence(ctxCheck, addAlice)
 	So(err, ShouldBeNil)
-	//	msg := govTypes.NewKuMsgDeposit(addAlice, accAlice, proposalID, amount)
 	msg := customizeKuMsgDeposit(addAlice, accAlice, proposalID, amount, transferAmount)
 
 	fee := types.Coins{types.NewInt64Coin(constants.DefaultBondDenom, 1000000)}

--- a/x/gov/types/kumsg.go
+++ b/x/gov/types/kumsg.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/KuChainNetwork/kuchain/chain/msg"
+	chainTypes "github.com/KuChainNetwork/kuchain/chain/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -39,6 +40,9 @@ func (msg KuMsgSubmitProposal) ValidateBasic() error {
 	msgData := MsgSubmitProposalBase{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
+	}
+	if !msg.GetAmount().IsEqual(msgData.InitialDeposit) {
+		return chainTypes.ErrKuMsgInconsistentAmount
 	}
 	if msgData.Proposer.Empty() {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msgData.Proposer.String())
@@ -81,7 +85,6 @@ func (msg KuMsgSubmitProposal) GetProposerAccountID() AccountID {
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return AccountID{}
 	}
-
 	return msgData.Proposer
 }
 
@@ -108,7 +111,10 @@ func (msg KuMsgDeposit) ValidateBasic() error {
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	if !msg.GetAmount().IsEqual(msgData.Amount) {
+		return chainTypes.ErrKuMsgInconsistentAmount
+	}
+	return msgData.ValidateBasic()
 }
 
 type KuMsgVote struct {
@@ -133,5 +139,5 @@ func (msg KuMsgVote) ValidateBasic() error {
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }

--- a/x/staking/handler_test.go
+++ b/x/staking/handler_test.go
@@ -1,7 +1,6 @@
 package staking_test
 
 import (
-	//"errors"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -97,7 +96,6 @@ func createValidator(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp, ad
 }
 
 func exitValidator(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp, addAlice sdk.AccAddress, accAlice types.AccountID, rate sdk.Dec, passed bool) error {
-	//auth sdk.AccAddress, valAddr types.AccountID, description Description, newRate *sdk.Dec
 	ctxCheck := app.BaseApp.NewContext(true, abci.Header{Height: app.LastBlockHeight() + 1})
 
 	origAuthSeq, origAuthNum, err := app.AccountKeeper().GetAuthSequence(ctxCheck, addAlice)
@@ -148,7 +146,6 @@ func delegationValidator(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp
 }
 
 func redelegateValidator(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp, addAlice sdk.AccAddress, accAlice, accJack, accValidator types.AccountID, amount types.Coin, passed bool) error {
-	//NewKuMsgRedelegate(auth sdk.AccAddress, delAddr types.AccountID, valSrcAddr, valDstAddr types.AccountID, amount types.Coin)
 	ctxCheck := app.BaseApp.NewContext(true, abci.Header{Height: app.LastBlockHeight() + 1})
 
 	origAuthSeq, origAuthNum, err := app.AccountKeeper().GetAuthSequence(ctxCheck, addAlice)
@@ -166,7 +163,6 @@ func redelegateValidator(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp
 }
 
 func unbondValidator(t *testing.T, wallet *simapp.Wallet, app *simapp.SimApp, addAlice sdk.AccAddress, accAlice, accJack types.AccountID, amount types.Coin, passed bool) error {
-	//NewKuMsgUnbond(auth sdk.AccAddress, delAddr types.AccountID, valAddr types.AccountID, amount types.Coin)
 	ctxCheck := app.BaseApp.NewContext(true, abci.Header{Height: app.LastBlockHeight() + 1})
 
 	origAuthSeq, origAuthNum, err := app.AccountKeeper().GetAuthSequence(ctxCheck, addAlice)
@@ -187,7 +183,6 @@ func newPubKey(pk string) (res crypto.PubKey) {
 	if err != nil {
 		panic(err)
 	}
-	//res, err = crypto.PubKeyFromBytes(pkBytes)
 	var pkEd ed25519.PubKeyEd25519
 	copy(pkEd[:], pkBytes)
 	return pkEd

--- a/x/staking/types/kumsg.go
+++ b/x/staking/types/kumsg.go
@@ -48,7 +48,7 @@ func (msg KuMsgCreateValidator) ValidateBasic() error {
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }
 
 type KuMsgDelegate struct {
@@ -79,7 +79,10 @@ func (msg KuMsgDelegate) ValidateBasic() error {
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	if (!msg.GetAmount().IsEqual(chainTypes.Coins{msgData.Amount})) {
+		return chainTypes.ErrKuMsgInconsistentAmount
+	}
+	return msgData.ValidateBasic()
 }
 
 type KuMsgEditValidator struct {
@@ -109,7 +112,7 @@ func (msg KuMsgEditValidator) ValidateBasic() error {
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }
 
 type KuMsgRedelegate struct {
@@ -140,7 +143,7 @@ func (msg KuMsgRedelegate) ValidateBasic() error {
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }
 
 type KuMsgUnbond struct {
@@ -170,5 +173,5 @@ func (msg KuMsgUnbond) ValidateBasic() error {
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }


### PR DESCRIPTION
## Summary

fix https://github.com/KuChainNetwork/Project-Deluge/issues/17

## Introduction

When there is transfer in kumsg, the amount of transfer and the amount required in msgdata can be constructed differently, which will cause the risk of currency theft, and increase the verification of whether the amount of transfer and the amount of msgdata are equal to avoid this problem

Add the corresponding test case

## Modifys

- gov/types/kumsg.go    KuMsgSubmitProposal  
- gov/types/kumsg.go    KuMsgDeposit
- staking/types/kumsg.go KuMsgDelegate
- staking/handle_test.go
- gov/handle_test.go