### PR TITLE
Implement `--minimum-gas-prices` param for kucd

### DIFF
--- a/chain/ante/setup.go
+++ b/chain/ante/setup.go
@@ -3,6 +3,7 @@ package ante
 import (
 	"fmt"
 
+	"github.com/KuChainNetwork/kuchain/chain/config"
 	"github.com/KuChainNetwork/kuchain/chain/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -40,6 +41,7 @@ func (sud SetUpContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 	}
 
 	newCtx = SetGasMeter(simulate, ctx, gasTx.GetGas())
+	newCtx = newCtx.WithMinGasPrices(config.GetFeePriceMiniLimit())
 
 	// Decorator will catch an OutOfGasPanic caused in the next antehandler
 	// AnteHandlers must have their own defer/recover in order for the BaseApp

--- a/chain/config/fee.go
+++ b/chain/config/fee.go
@@ -1,16 +1,19 @@
 package config
 
-import "github.com/KuChainNetwork/kuchain/chain/types"
-
-var (
-	feePriceMiniLimit types.Coins
+import (
+	"github.com/KuChainNetwork/kuchain/chain/types/coin"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func SetFeePriceMiniLimit(f types.Coins) {
+var (
+	feePriceMiniLimit coin.DecCoins
+)
+
+func SetFeePriceMiniLimit(f coin.DecCoins) {
 	feePriceMiniLimit = f
 }
 
 // GetFeeMiniLimit get fee gas price mini limit
-func GetFeePriceMiniLimit() types.Coins {
-	return feePriceMiniLimit
+func GetFeePriceMiniLimit() sdk.DecCoins {
+	return feePriceMiniLimit.ToSDK()
 }

--- a/chain/config/fee.go
+++ b/chain/config/fee.go
@@ -1,0 +1,16 @@
+package config
+
+import "github.com/KuChainNetwork/kuchain/chain/types"
+
+var (
+	feePriceMiniLimit types.Coins
+)
+
+func SetFeePriceMiniLimit(f types.Coins) {
+	feePriceMiniLimit = f
+}
+
+// GetFeeMiniLimit get fee gas price mini limit
+func GetFeePriceMiniLimit() types.Coins {
+	return feePriceMiniLimit
+}

--- a/cmd/kucd/main.go
+++ b/cmd/kucd/main.go
@@ -99,7 +99,6 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application
 	return app.NewKuchainApp(
 		logger, db, traceStore, true, invCheckPeriod,
 		baseapp.SetPruning(store.NewPruningOptionsFromString(viper.GetString("pruning"))),
-		//baseapp.SetMinGasPrices(miniGasPrice), FIXME: min gas
 		baseapp.SetHaltHeight(viper.GetUint64(server.FlagHaltHeight)),
 		baseapp.SetHaltTime(viper.GetUint64(server.FlagHaltTime)),
 		baseapp.SetInterBlockCache(cache),

--- a/cmd/kucd/main.go
+++ b/cmd/kucd/main.go
@@ -26,8 +26,10 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/KuChainNetwork/kuchain/app"
+	"github.com/KuChainNetwork/kuchain/chain/config"
 	chainCfg "github.com/KuChainNetwork/kuchain/chain/config"
 	"github.com/KuChainNetwork/kuchain/chain/constants"
+	"github.com/KuChainNetwork/kuchain/chain/types"
 	kuLog "github.com/KuChainNetwork/kuchain/utils/log"
 	genTypes "github.com/KuChainNetwork/kuchain/x/genutil/types"
 )
@@ -95,6 +97,12 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application
 	if miniGasPrice == "" {
 		miniGasPrice = constants.MinGasPriceString
 	}
+
+	miniGasPriceCoins, err := types.ParseCoins(miniGasPrice)
+	if err != nil {
+		panic(err)
+	}
+	config.SetFeePriceMiniLimit(miniGasPriceCoins)
 
 	return app.NewKuchainApp(
 		logger, db, traceStore, true, invCheckPeriod,

--- a/cmd/kucd/main.go
+++ b/cmd/kucd/main.go
@@ -98,7 +98,7 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application
 		miniGasPrice = constants.MinGasPriceString
 	}
 
-	miniGasPriceCoins, err := types.ParseCoins(miniGasPrice)
+	miniGasPriceCoins, err := types.ParseDecCoins(miniGasPrice)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary

Implement the mini gas price for kucd, so node can configure the mini gas price.

## Introduction

Kuchain coins type has some different with cosmos-sdk, so kuchain cannot use the cosmos default way to configure the mini gas price.

## Modifys

- Del the old gas-mini set call
- Add a mini gas config value in config package
- use this mini gas in ante.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes