### PR TITLE
Delete `ValidateBasic` function for KuMsg

### DIFF
--- a/chain/msg/handler.go
+++ b/chain/msg/handler.go
@@ -53,7 +53,7 @@ func onHandlerKuMsg(ctx Context, k AssetTransfer, msg KuTransfMsg) error {
 	}
 
 	// check validate for safe
-	if err := msg.ValidateBasic(); err != nil {
+	if err := msg.ValidateTransfer(); err != nil {
 		return err
 	}
 

--- a/chain/types/interfaces.go
+++ b/chain/types/interfaces.go
@@ -21,13 +21,15 @@ type AccountAuther interface {
 
 // KuTransfMsg ku Msg
 type KuTransfMsg interface {
-	sdk.Msg
-
+	Route() string
+	Type() string
+	GetSignBytes() []byte
+	GetSigners() []AccAddress
 	GetFrom() AccountID
 	GetTo() AccountID
 	GetAmount() Coins
-	Type() string
 	GetData() []byte
+	ValidateTransfer() error
 }
 
 var _ KuTransfMsg = &KuMsg{}

--- a/chain/types/msg.go
+++ b/chain/types/msg.go
@@ -77,7 +77,7 @@ func (msg KuMsg) GetSigners() []sdk.AccAddress {
 }
 
 // ValidateBasic does a simple validation check that doesn't require access to any other information.
-func (msg KuMsg) ValidateBasic() error {
+func (msg KuMsg) ValidateTransfer() error {
 	if msg.Router.Empty() {
 		return ErrKuMsgMissingRouter
 	}

--- a/x/account/types/msgs.go
+++ b/x/account/types/msgs.go
@@ -53,7 +53,7 @@ func (msg MsgCreateAccount) GetData() (MsgCreateAccountData, error) {
 }
 
 func (msg MsgCreateAccount) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 
@@ -113,7 +113,7 @@ func (msg MsgUpdateAccountAuth) GetData() (MsgUpdateAccountAuthData, error) {
 }
 
 func (msg MsgUpdateAccountAuth) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 

--- a/x/asset/handler.go
+++ b/x/asset/handler.go
@@ -16,8 +16,6 @@ import (
 func NewHandler(k keeper.AssetCoinsKeeper) msg.Handler {
 	return func(ctx chainTypes.Context, msg sdk.Msg) (*sdk.Result, error) {
 		switch msg := msg.(type) {
-		case *types.KuMsg:
-			return handleKuMsg(ctx)
 		case *types.MsgTransfer:
 			return handleMsgTransfer(ctx, k, msg)
 		case *types.MsgCreateCoin:

--- a/x/asset/types/msgs.go
+++ b/x/asset/types/msgs.go
@@ -37,7 +37,7 @@ func NewMsgTransfer(auth types.AccAddress, from types.AccountID, to types.Accoun
 }
 
 func (msg MsgTransfer) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 
@@ -94,7 +94,7 @@ func (msg MsgCreateCoin) GetData() (MsgCreateCoinData, error) {
 }
 
 func (msg MsgCreateCoin) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 
@@ -172,7 +172,7 @@ func (msg MsgIssueCoin) GetData() (MsgIssueCoinData, error) {
 }
 
 func (msg MsgIssueCoin) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 
@@ -236,7 +236,7 @@ func (msg MsgBurnCoin) GetData() (MsgBurnCoinData, error) {
 }
 
 func (msg MsgBurnCoin) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 
@@ -302,7 +302,7 @@ func (msg MsgLockCoin) GetData() (MsgLockCoinData, error) {
 }
 
 func (msg MsgLockCoin) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 
@@ -372,7 +372,7 @@ func (msg MsgUnlockCoin) GetData() (MsgUnlockCoinData, error) {
 }
 
 func (msg MsgUnlockCoin) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 

--- a/x/distribution/alias.go
+++ b/x/distribution/alias.go
@@ -77,8 +77,6 @@ var (
 	NewMsgSetWithdrawAccountId                 = types.NewMsgSetWithdrawAccountId
 	NewMsgWithdrawDelegatorReward              = types.NewMsgWithdrawDelegatorReward
 	NewMsgWithdrawValidatorCommission          = types.NewMsgWithdrawValidatorCommission
-	MsgFundCommunityPool                       = types.NewMsgFundCommunityPool
-	NewCommunityPoolSpendProposal              = types.NewCommunityPoolSpendProposal
 	NewQueryValidatorOutstandingRewardsParams  = types.NewQueryValidatorOutstandingRewardsParams
 	NewQueryValidatorCommissionParams          = types.NewQueryValidatorCommissionParams
 	NewQueryValidatorSlashesParams             = types.NewQueryValidatorSlashesParams

--- a/x/distribution/client/rest/tx.go
+++ b/x/distribution/client/rest/tx.go
@@ -207,44 +207,6 @@ func withdrawValidatorRewardsHandlerFn(cliCtx context.CLIContext) http.HandlerFu
 	}
 }
 
-func fundCommunityPoolHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		var req fundCommunityPoolReq
-		if !rest.ReadRESTReq(w, r, cliCtx.Codec, &req) {
-			return
-		}
-
-		req.BaseReq = req.BaseReq.Sanitize()
-
-		amount, err := chainTypes.ParseCoins(req.Amount)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		depositor, err := chainTypes.NewAccountIDFromStr(req.DepositorAcc)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		ctx := txutil.NewKuCLICtx(cliCtx).WithFromAccount(depositor)
-		auth, err := txutil.QueryAccountAuth(ctx, depositor)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		msg := types.NewMsgFundCommunityPool(auth, amount, depositor)
-		if err := msg.ValidateBasic(); err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		txutil.WriteGenerateStdTxResponse(w, txutil.NewKuCLICtx(cliCtx), req.BaseReq, []sdk.Msg{msg})
-	}
-}
-
 func checkDelegatorAddressVar(w http.ResponseWriter, r *http.Request) (chainTypes.AccountID, bool) {
 	accID, err := chainTypes.NewAccountIDFromStr(mux.Vars(r)["delegatorAddr"])
 	if err != nil {
@@ -256,7 +218,6 @@ func checkDelegatorAddressVar(w http.ResponseWriter, r *http.Request) (chainType
 }
 
 func checkValidatorAddressVar(w http.ResponseWriter, r *http.Request) (chainTypes.AccountID, bool) {
-	// FIXME: support accountID
 	addr, err := chainTypes.NewAccountIDFromStr(mux.Vars(r)["validatorAddr"])
 	if err != nil {
 		rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/x/distribution/handler.go
+++ b/x/distribution/handler.go
@@ -21,9 +21,6 @@ func NewHandler(k keeper.Keeper) msg.Handler {
 		case types.MsgWithdrawValidatorCommission:
 			return handleMsgWithdrawValidatorCommission(ctx, msg, k)
 
-		case types.MsgFundCommunityPool:
-			return handleMsgFundCommunityPool(ctx, msg, k)
-
 		default:
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized distribution message type: %T", msg)
 		}
@@ -102,33 +99,6 @@ func handleMsgWithdrawValidatorCommission(ctx chainTypes.Context, msg types.MsgW
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 			sdk.NewAttribute(sdk.AttributeKeySender, dataMsg.ValidatorAccountId.String()),
-		),
-	)
-
-	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
-}
-
-func handleMsgFundCommunityPool(ctx chainTypes.Context, msg types.MsgFundCommunityPool, k keeper.Keeper) (*sdk.Result, error) {
-	msgData, err := msg.GetData()
-	ctx.RequireAuth(msgData.Depositor)
-
-	if err != nil {
-		return nil, sdkerrors.Wrap(err, "msg create account data unmarshal error")
-	}
-
-	if err := ctx.RequireTransfer(types.ModuleAccountID, msgData.Amount); err != nil {
-		return nil, sdkerrors.Wrap(err, "fund community pool no transfer enough")
-	}
-
-	if err := k.FundCommunityPool(ctx.Context(), msgData.Amount, msgData.Depositor); err != nil {
-		return nil, sdkerrors.Wrap(err, "fund community pool error")
-	}
-
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msgData.Depositor.String()),
 		),
 	)
 

--- a/x/distribution/types/codec.go
+++ b/x/distribution/types/codec.go
@@ -16,9 +16,6 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(&MsgSetWithdrawAccountIdData{}, "kuchain/MsgSetWithdrawAccountIdData", nil)
 	cdc.RegisterConcrete(MsgSetWithdrawAccountId{}, "kuchain/MsgSetWithdrawAccountId", nil)
 
-	cdc.RegisterConcrete(MsgFundCommunityPool{}, "cosmos-sdk/MsgFundCommunityPool", nil)
-	cdc.RegisterConcrete(&MsgFundCommunityPoolData{}, "kuchain/MsgFundCommunityPoolData", nil)
-
 	cdc.RegisterConcrete(CommunityPoolSpendProposal{}, "cosmos-sdk/CommunityPoolSpendProposal", nil)
 }
 

--- a/x/distribution/types/msg.go
+++ b/x/distribution/types/msg.go
@@ -223,31 +223,3 @@ func (m MsgFundCommunityPoolData) Marshal() ([]byte, error) {
 func (m *MsgFundCommunityPoolData) Unmarshal(b []byte) error {
 	return ModuleCdc.UnmarshalJSON(b, m)
 }
-
-type MsgFundCommunityPool struct {
-	KuMsg
-}
-
-// NewMsgFundCommunityPool returns a new MsgFundCommunityPool with a sender and
-// a funding amount.
-func NewMsgFundCommunityPool(auth AccAddress, amount Coins, depositor AccountID) MsgFundCommunityPool {
-	return MsgFundCommunityPool{
-		*msg.MustNewKuMsg(
-			MustName(RouterKey),
-			msg.WithAuth(auth),
-			msg.WithTransfer(depositor, ModuleAccountID, amount),
-			msg.WithData(Cdc(), &MsgFundCommunityPoolData{
-				Amount:    amount,
-				Depositor: depositor,
-			}),
-		),
-	}
-}
-
-func (m MsgFundCommunityPool) GetData() (MsgFundCommunityPoolData, error) {
-	res := MsgFundCommunityPoolData{}
-	if err := m.UnmarshalData(Cdc(), &res); err != nil {
-		return MsgFundCommunityPoolData{}, sdkerrors.Wrapf(chainType.ErrKuMsgDataUnmarshal, "%s", err.Error())
-	}
-	return res, nil
-}

--- a/x/distribution/types/msg.go
+++ b/x/distribution/types/msg.go
@@ -62,7 +62,7 @@ func (m MsgSetWithdrawAccountId) ValidateBasic() error {
 		}
 	}
 
-	return m.KuMsg.ValidateBasic()
+	return m.KuMsg.ValidateTransfer()
 }
 
 func NewMsgSetWithdrawAccountId(auth AccAddress, delAddr, withdrawAddr AccountID) MsgSetWithdrawAccountId {
@@ -122,7 +122,7 @@ func (m MsgWithdrawDelegatorReward) ValidateBasic() error {
 		}
 	}
 
-	return m.KuMsg.ValidateBasic()
+	return m.KuMsg.ValidateTransfer()
 }
 
 func (m MsgWithdrawDelegatorReward) GetData() (MsgWithdrawDelegatorRewardData, error) {
@@ -189,7 +189,7 @@ func (m MsgWithdrawValidatorCommission) ValidateBasic() error {
 		}
 	}
 
-	return m.KuMsg.ValidateBasic()
+	return m.KuMsg.ValidateTransfer()
 }
 
 func NewMsgWithdrawValidatorCommission(auth AccAddress, valAddr AccountID) MsgWithdrawValidatorCommission {

--- a/x/gov/types/kumsg.go
+++ b/x/gov/types/kumsg.go
@@ -30,7 +30,7 @@ func NewKuMsgSubmitProposal(auth sdk.AccAddress, content Content, initialDeposit
 }
 
 func (msg KuMsgSubmitProposal) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 	if msg.Content == nil {
@@ -101,14 +101,14 @@ func NewKuMsgDeposit(auth sdk.AccAddress, depositor AccountID, proposalID uint64
 }
 
 func (msg KuMsgDeposit) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 	msgData := MsgDeposit{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }
 
 type KuMsgVote struct {
@@ -126,12 +126,12 @@ func NewKuMsgVote(auth sdk.AccAddress, voter AccountID, proposalID uint64, optio
 }
 
 func (msg KuMsgVote) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 	msgData := MsgVote{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }

--- a/x/slashing/types/kumsg.go
+++ b/x/slashing/types/kumsg.go
@@ -26,12 +26,12 @@ func NewKuMsgUnjail(auth sdk.AccAddress, validatorAddr AccountID) KuMsgUnjail {
 }
 
 func (msg KuMsgUnjail) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 	msgData := MsgUnjail{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }

--- a/x/staking/types/kumsg.go
+++ b/x/staking/types/kumsg.go
@@ -41,14 +41,14 @@ func NewKuMsgCreateValidator(auth sdk.AccAddress, valAddr chainTypes.AccountID, 
 }
 
 func (msg KuMsgCreateValidator) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 	msgData := MsgCreateValidator{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }
 
 type KuMsgDelegate struct {
@@ -72,14 +72,14 @@ func NewKuMsgDelegate(auth sdk.AccAddress, delAddr chainTypes.AccountID, valAddr
 }
 
 func (msg KuMsgDelegate) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 	msgData := MsgDelegate{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }
 
 type KuMsgEditValidator struct {
@@ -102,14 +102,14 @@ func NewKuMsgEditValidator(auth sdk.AccAddress, valAddr chainTypes.AccountID, de
 }
 
 func (msg KuMsgEditValidator) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 	msgData := MsgEditValidator{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }
 
 type KuMsgRedelegate struct {
@@ -133,14 +133,14 @@ func NewKuMsgRedelegate(auth sdk.AccAddress, delAddr chainTypes.AccountID, valSr
 }
 
 func (msg KuMsgRedelegate) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 	msgData := MsgBeginRedelegate{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }
 
 type KuMsgUnbond struct {
@@ -163,12 +163,12 @@ func NewKuMsgUnbond(auth sdk.AccAddress, delAddr chainTypes.AccountID, valAddr c
 }
 
 func (msg KuMsgUnbond) ValidateBasic() error {
-	if err := msg.KuMsg.ValidateBasic(); err != nil {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
 	msgData := MsgUndelegate{}
 	if err := msg.UnmarshalData(Cdc(), &msgData); err != nil {
 		return err
 	}
- 	return msgData.ValidateBasic()
+	return msgData.ValidateBasic()
 }


### PR DESCRIPTION
## Summary

Delete `ValidateBasic` function for KuMsg, So Msg should not forgot to make a `ValidateBasic` func.

## Introduction

All Msg in Kuchain is ext the KuMsg struct which contain a transfer. KuMsg has `ValidateBasic` function, and if a Msg based on KuMsg not imp the `ValidateBasic` function, it can build success, but is wrong in most times.

So KuMsg will change the `ValidateBasic` to `ValidateTransfer`, and should call in all `ValidateBasic` for each Msgs.

## Modifys

- Delete useless `FundCommunityPool`
- Change KuMsg `ValidateBasic` to `ValidateTransfer`

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes