### PR TITLE
Add Cmd and Rest Url Support for Burn Tokens Msg

### DIFF
--- a/x/asset/client/cli/tx.go
+++ b/x/asset/client/cli/tx.go
@@ -29,6 +29,7 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 		Transfer(cdc),
 		Create(cdc),
 		Issue(cdc),
+		Burn(cdc),
 		LockCoin(cdc),
 		UnlockCoin(cdc),
 	)

--- a/x/asset/client/rest/rest.go
+++ b/x/asset/client/rest/rest.go
@@ -38,6 +38,10 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 		IssueRequestHandlerFn(cliCtx),
 	).Methods("POST")
 	r.HandleFunc(
+		"/assets/burn",
+		BurnRequestHandlerFn(cliCtx),
+	)
+	r.HandleFunc(
 		"/assets/lock",
 		LockRequestHandlerFn(cliCtx),
 	).Methods("POST")

--- a/x/asset/types/msgs.go
+++ b/x/asset/types/msgs.go
@@ -212,8 +212,8 @@ func (msg MsgBurnCoinData) Sender() AccountID {
 }
 
 // NewMsgBurn new issue msg
-func NewMsgBurn(auth types.AccAddress, id types.AccountID, amount types.Coin) MsgIssueCoin {
-	return MsgIssueCoin{
+func NewMsgBurn(auth types.AccAddress, id types.AccountID, amount types.Coin) MsgBurnCoin {
+	return MsgBurnCoin{
 		*msg.MustNewKuMsg(
 			RouterKeyName,
 			msg.WithAuth(auth),


### PR DESCRIPTION
## Summary

Add cmd and rest Url support for Burn Tokens Msg.

## Introduction

In Last Version, there is no cmd and url for burn coins msg. so we need add it.

## Modifys

- add `kucli tx asset burn [account] [amount]` cmd to burn coins.
- add rest `/assets/burn` for burn coins by url.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes