### PR TITLE
Add Coinpower Exercise Msg and Handler

### DIFF
--- a/x/asset/client/cli/power.go
+++ b/x/asset/client/cli/power.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"bufio"
+
+	"github.com/KuChainNetwork/kuchain/chain/client/flags"
+	"github.com/KuChainNetwork/kuchain/chain/client/txutil"
+	chainTypes "github.com/KuChainNetwork/kuchain/chain/types"
+	"github.com/KuChainNetwork/kuchain/x/asset/types"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/spf13/cobra"
+)
+
+// Exercise will commit a Exercise msg to chain
+func Exercise(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "exercise [accountID] [amount]",
+		Short: "Exercise coins from coinpowers",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			txBldr := txutil.NewTxBuilderFromCLI(inBuf).WithTxEncoder(txutil.GetTxEncoder(cdc))
+			cliCtx := context.NewCLIContextWithInput(inBuf).WithCodec(cdc)
+
+			id, err := types.NewAccountIDFromStr(args[0])
+			if err != nil {
+				return sdkerrors.Wrapf(err, "account id %s parse error", args[0])
+			}
+
+			amount, err := chainTypes.ParseCoin(args[1])
+			if err != nil {
+				return err
+			}
+
+			ctx := txutil.NewKuCLICtx(cliCtx).WithFromAccount(id)
+			auth, err := txutil.QueryAccountAuth(ctx, id)
+			if err != nil {
+				return sdkerrors.Wrapf(err, "query account %s auth error", id)
+			}
+
+			msg := types.NewMsgExercise(auth, id, amount)
+			return txutil.GenerateOrBroadcastMsgs(ctx, txBldr, []sdk.Msg{msg})
+		},
+	}
+
+	cmd = flags.PostCommands(cmd)[0]
+	return cmd
+}

--- a/x/asset/client/cli/tx.go
+++ b/x/asset/client/cli/tx.go
@@ -32,6 +32,7 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 		Burn(cdc),
 		LockCoin(cdc),
 		UnlockCoin(cdc),
+		Exercise(cdc),
 	)
 
 	return txCmd

--- a/x/asset/client/rest/rest.go
+++ b/x/asset/client/rest/rest.go
@@ -49,4 +49,8 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 		"/assets/unlock",
 		UnlockRequestHandlerFn(cliCtx),
 	).Methods("POST")
+	r.HandleFunc(
+		"/assets/exercise",
+		ExerciseRequestHandlerFn(cliCtx),
+	).Methods("POST")
 }

--- a/x/asset/keeper/keeper.go
+++ b/x/asset/keeper/keeper.go
@@ -21,6 +21,7 @@ type AssetCoinsKeeper interface {
 	Burn(ctx sdk.Context, id types.AccountID, amt types.Coin) error
 	LockCoins(ctx sdk.Context, account types.AccountID, unlockBlockHeight int64, coins types.Coins) error
 	UnLockCoins(ctx sdk.Context, account types.AccountID, coins types.Coins) error
+	ExerciseCoinPower(ctx sdk.Context, id types.AccountID, amt types.Coin) error
 }
 
 // AssetViewKeeper keeper view interface for asset module

--- a/x/asset/keeper/keeper_power.go
+++ b/x/asset/keeper/keeper_power.go
@@ -55,13 +55,17 @@ func (a AssetKeeper) subCoinPower(ctx sdk.Context, id types.AccountID, amt Coins
 		return coins, nil
 	}
 
+	if amt.IsAnyNegative() {
+		return Coins{}, sdkerrors.Wrapf(types.ErrAssetCoinNoEnough, "amt should not be negative")
+	}
+
 	subed, hasNeg := coins.SafeSub(amt)
 	if hasNeg {
 		return Coins{}, sdkerrors.Wrapf(types.ErrAssetCoinNoEnough, "sub coin power error no enough")
 	}
 
 	if subed == nil {
-		subed = NewInt64Coins(amt[0].Denom, 0)
+		subed = NewCoins()
 	}
 
 	if err := a.setCoinsPower(ctx, id, subed); err != nil {
@@ -127,7 +131,7 @@ func (a AssetKeeper) CoinsToPower(ctx sdk.Context, from, to types.AccountID, amt
 
 // ExerciseCoinPower exercise coin power to get coins to account
 func (a AssetKeeper) ExerciseCoinPower(ctx sdk.Context, id types.AccountID, amt types.Coin) error {
-	if _, err := a.subCoinPower(ctx, id, Coins{amt}); err != nil {
+	if _, err := a.subCoinPower(ctx, id, NewCoins(amt)); err != nil {
 		return sdkerrors.Wrapf(err, "get %s coins powers in exercise error", id)
 	}
 

--- a/x/asset/keeper/keeper_power.go
+++ b/x/asset/keeper/keeper_power.go
@@ -59,6 +59,8 @@ func (a AssetKeeper) subCoinPower(ctx sdk.Context, id types.AccountID, amt Coins
 		return Coins{}, sdkerrors.Wrapf(types.ErrAssetCoinNoEnough, "amt should not be negative")
 	}
 
+	ctx.Logger().Debug("sub coin power", "c", coins, "amt", amt)
+
 	subed, hasNeg := coins.SafeSub(amt)
 	if hasNeg {
 		return Coins{}, sdkerrors.Wrapf(types.ErrAssetCoinNoEnough, "sub coin power error no enough")
@@ -131,6 +133,12 @@ func (a AssetKeeper) CoinsToPower(ctx sdk.Context, from, to types.AccountID, amt
 
 // ExerciseCoinPower exercise coin power to get coins to account
 func (a AssetKeeper) ExerciseCoinPower(ctx sdk.Context, id types.AccountID, amt types.Coin) error {
+	ctx.Logger().Debug("exercise coin power", "id", id, "amount", amt)
+
+	if amt.IsZero() {
+		return nil
+	}
+
 	if _, err := a.subCoinPower(ctx, id, NewCoins(amt)); err != nil {
 		return sdkerrors.Wrapf(err, "get %s coins powers in exercise error", id)
 	}

--- a/x/asset/keeper/keeper_power_test.go
+++ b/x/asset/keeper/keeper_power_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/KuChainNetwork/kuchain/chain/constants"
 	"github.com/KuChainNetwork/kuchain/chain/types"
 	"github.com/KuChainNetwork/kuchain/test/simapp"
+	assetTypes "github.com/KuChainNetwork/kuchain/x/asset/types"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -20,6 +21,88 @@ func TestCoinPower(t *testing.T) {
 
 		coins := app.AssetKeeper().GetCoinPowers(ctx, account1)
 		So(coins, simapp.ShouldEq, amt)
+	})
+
+}
+
+func TestCoinPowerExercise(t *testing.T) {
+	app, ctx := createTestApp()
+
+	amt := types.NewCoins(types.NewInt64Coin(constants.DefaultBondDenom, 100000))
+
+	Convey("test coin power exercise", t, func() {
+		Convey("step1 : test coin to coin power", func() {
+			err := app.AssetKeeper().CoinsToPower(ctx, account1, account1, amt)
+			So(err, ShouldBeNil)
+
+			coins := app.AssetKeeper().GetCoinPowers(ctx, account1)
+			So(coins, simapp.ShouldEq, amt)
+		})
+
+		Convey("step2 : test coin power exercise", func() {
+			ctx := app.NewTestContext()
+			amtAll := app.AssetKeeper().GetAllBalances(ctx, account1)
+			coinPowerAll := app.AssetKeeper().GetCoinPowers(ctx, account1)
+
+			amte := types.NewInt64Coin(constants.DefaultBondDenom, 1000)
+
+			err := app.AssetKeeper().ExerciseCoinPower(ctx, account1, amte)
+			So(err, ShouldBeNil)
+			So(amtAll.Add(amte), simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account1))
+			So(coinPowerAll.Sub(types.NewCoins(amte)), simapp.ShouldEq, app.AssetKeeper().GetCoinPowers(ctx, account1))
+		})
+
+		Convey("step3 : test coin power exercise zero", func() {
+			ctx := app.NewTestContext()
+			amtAll := app.AssetKeeper().GetAllBalances(ctx, account1)
+			coinPowerAll := app.AssetKeeper().GetCoinPowers(ctx, account1)
+
+			err := app.AssetKeeper().ExerciseCoinPower(ctx, account1, types.NewInt64Coin(constants.DefaultBondDenom, 0))
+			So(err, ShouldBeNil)
+			So(amtAll, simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account1))
+			So(coinPowerAll, simapp.ShouldEq, app.AssetKeeper().GetCoinPowers(ctx, account1))
+		})
+
+		Convey("step4 : test coin power exercise all", func() {
+			ctx := app.NewTestContext()
+			amtAll := app.AssetKeeper().GetAllBalances(ctx, account1)
+			coinPowerAll := app.AssetKeeper().GetCoinPowers(ctx, account1)
+
+			err := app.AssetKeeper().ExerciseCoinPower(ctx, account1, coinPowerAll[0])
+			So(err, ShouldBeNil)
+			So(amtAll.Add(coinPowerAll...), simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account1))
+			So(types.NewCoins(), simapp.ShouldEq, app.AssetKeeper().GetCoinPowers(ctx, account1))
+		})
+	})
+
+}
+
+func TestCoinPowerExerciseErrors(t *testing.T) {
+	app, ctx := createTestApp()
+
+	amt := types.NewCoins(types.NewInt64Coin(constants.DefaultBondDenom, 100000))
+
+	Convey("test coin power exercise errors", t, func() {
+		Convey("step1 : test coin to coin power", func() {
+			err := app.AssetKeeper().CoinsToPower(ctx, account1, account1, amt)
+			So(err, ShouldBeNil)
+
+			coins := app.AssetKeeper().GetCoinPowers(ctx, account1)
+			So(coins, simapp.ShouldEq, amt)
+		})
+
+		Convey("step2 : test coin power exercise error by no enough", func() {
+			ctx := app.NewTestContext()
+			amtAll := app.AssetKeeper().GetAllBalances(ctx, account1)
+			coinPowerAll := app.AssetKeeper().GetCoinPowers(ctx, account1)
+
+			amte := types.NewInt64Coin(constants.DefaultBondDenom, 10000000000)
+
+			err := app.AssetKeeper().ExerciseCoinPower(ctx, account1, amte)
+			So(err, simapp.ShouldErrIs, assetTypes.ErrAssetCoinNoEnough)
+			So(amtAll, simapp.ShouldEq, app.AssetKeeper().GetAllBalances(ctx, account1))
+			So(coinPowerAll, simapp.ShouldEq, app.AssetKeeper().GetCoinPowers(ctx, account1))
+		})
 	})
 
 }

--- a/x/asset/types/codec.go
+++ b/x/asset/types/codec.go
@@ -28,6 +28,8 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(&MsgLockCoin{}, "asset/lock", nil)
 	cdc.RegisterConcrete(&MsgUnlockCoinData{}, "asset/unlockData", nil)
 	cdc.RegisterConcrete(&MsgUnlockCoin{}, "asset/unlock", nil)
+	cdc.RegisterConcrete(&MsgExerciseCoinData{}, "asset/exerciseData", nil)
+	cdc.RegisterConcrete(&MsgExerciseCoin{}, "asset/exercise", nil)
 }
 
 // Cdc get codec for types

--- a/x/asset/types/errors.go
+++ b/x/asset/types/errors.go
@@ -23,4 +23,5 @@ var (
 	ErrAssetCoinMustSupplyNeedGTInitSupply   = sdkerrors.Register(ModuleName, 18, "coin max_supply need > init_supply")
 	ErrAssetIssueToHeightMustGTCurrentHeight = sdkerrors.Register(ModuleName, 19, "coin issue to height must > current height")
 	ErrAssetSymbolError                      = sdkerrors.Register(ModuleName, 20, "asset symbol error")
+	ErrAssetCoinNoZero                       = sdkerrors.Register(ModuleName, 21, "amount should not be zero")
 )

--- a/x/asset/types/events.go
+++ b/x/asset/types/events.go
@@ -10,6 +10,7 @@ const (
 	EventTypeTransfer = "transfer"
 	EventTypeLock     = "lock"
 	EventTypeUnlock   = "unlock"
+	EventTypeExercise = "exercise"
 )
 
 const (

--- a/x/asset/types/msgs.go
+++ b/x/asset/types/msgs.go
@@ -456,5 +456,9 @@ func (msg MsgExerciseCoin) ValidateBasic() error {
 		return ErrAssetCoinNoEnough
 	}
 
+	if data.Amount.IsZero() {
+		return ErrAssetCoinNoZero
+	}
+
 	return nil
 }

--- a/x/asset/types/msgs.go
+++ b/x/asset/types/msgs.go
@@ -395,3 +395,66 @@ func (msg MsgUnlockCoin) ValidateBasic() error {
 
 	return nil
 }
+
+type MsgExerciseCoin struct {
+	types.KuMsg
+}
+
+type MsgExerciseCoinData struct {
+	Id     AccountID `json:"id" yaml:"id"`
+	Amount Coin      `json:"amount" yaml:"amount"`
+}
+
+// Type imp for data KuMsgData
+func (MsgExerciseCoinData) Type() types.Name { return types.MustName("exercise") }
+
+func (msg MsgExerciseCoinData) Sender() AccountID {
+	return msg.Id
+}
+
+// NewMsgBurn new issue msg
+func NewMsgExercise(auth types.AccAddress, id types.AccountID, amount types.Coin) MsgExerciseCoin {
+	return MsgExerciseCoin{
+		*msg.MustNewKuMsg(
+			RouterKeyName,
+			msg.WithAuth(auth),
+			msg.WithData(Cdc(), &MsgExerciseCoinData{
+				Id:     id,
+				Amount: amount,
+			}),
+		),
+	}
+}
+
+func (msg MsgExerciseCoin) GetData() (MsgExerciseCoinData, error) {
+	res := MsgExerciseCoinData{}
+	if err := msg.UnmarshalData(Cdc(), &res); err != nil {
+		return MsgExerciseCoinData{}, sdkerrors.Wrapf(types.ErrKuMsgDataUnmarshal, "%s", err.Error())
+	}
+	return res, nil
+}
+
+func (msg MsgExerciseCoin) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
+		return err
+	}
+
+	data, err := msg.GetData()
+	if err != nil {
+		return err
+	}
+
+	if data.Id.Empty() {
+		return types.ErrKuMsgAccountIDNil
+	}
+
+	if err := types.ValidateDenom(data.Amount.Denom); err != nil {
+		return err
+	}
+
+	if data.Amount.IsNegative() {
+		return ErrAssetCoinNoEnough
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

add `MsgExerciseCoin` and handler in asset module.

## Introduction

In Kuchain, we add `coinpower` for the way to give user token by chain logic.

Coinpower is not the coins, user need exercise it to coins.
So user should commit `MsgExerciseCoin` Msg to chain to do it.

## Modifys

- Add `MsgExerciseCoin` msg type.
- Add handler for `MsgExerciseCoin` in asset module.
- Add some test for keeper `ExerciseCoinPower` api.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes