### PR TITLE
Fix Create a reward event for the proposer Cannot get validator account

### DIFF
--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -59,7 +59,7 @@ func (k Keeper) AllocateTokens(
 			sdk.NewEvent(
 				types.EventTypeProposerReward,
 				sdk.NewAttribute(sdk.AttributeKeyAmount, proposerReward.String()),
-				sdk.NewAttribute(types.AttributeKeyValidator, proposerValidator.GetOperator().String()),
+				sdk.NewAttribute(types.AttributeKeyValidator, proposerValidator.GetOperatorAccountID().String()),
 			),
 		)
 
@@ -113,7 +113,7 @@ func (k Keeper) AllocateTokensToValidator(ctx sdk.Context, val types.StakingExpo
 		sdk.NewEvent(
 			types.EventTypeCommission,
 			sdk.NewAttribute(sdk.AttributeKeyAmount, commission.String()),
-			sdk.NewAttribute(types.AttributeKeyValidator, val.GetOperator().String()),
+			sdk.NewAttribute(types.AttributeKeyValidator, val.GetOperatorAccountID().String()),
 		),
 	)
 	currentCommission := k.GetValidatorAccumulatedCommission(ctx, val.GetOperatorAccountID())
@@ -133,7 +133,7 @@ func (k Keeper) AllocateTokensToValidator(ctx sdk.Context, val types.StakingExpo
 		sdk.NewEvent(
 			types.EventTypeRewards,
 			sdk.NewAttribute(sdk.AttributeKeyAmount, tokens.String()),
-			sdk.NewAttribute(types.AttributeKeyValidator, val.GetOperator().String()),
+			sdk.NewAttribute(types.AttributeKeyValidator, val.GetOperatorAccountID().String()),
 		),
 	)
 	outstanding := k.GetValidatorOutstandingRewards(ctx, val.GetOperatorAccountID())


### PR DESCRIPTION

## Summary
when creating proposer event, commission event, reward event, can not get validator account


Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes