### PR TITLE
Add version cmd to get build and version info for Kuchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 #!/usr/bin/make -f
 
 PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
-#VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
-VERSION := '0.0.1'
+VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
+TIME_BEGIN := $(shell date -u +"%Y-%m-%d %H:%M.%S")
+BRANCH := $(shell echo $(shell git rev-parse --abbrev-ref HEAD) | sed 's/^v//')
 
-MAIN_SYMBOL := 'kuchain'
-CORE_SYMBOL := 'sys'
+$(info "Kuchain Version: ${VERSION} ${SDK_PACK} in ${TIME_BEGIN}")
+$(info "Current branch: ${BRANCH}")
+
+MAIN_SYMBOL := kuchain
+CORE_SYMBOL := sys
 
 export GO111MODULE = on
 
@@ -57,6 +61,10 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=$(MAIN_SYMBOL) \
 		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
+		  -X github.com/KuChainNetwork/kuchain/chain/constants.KuchainBuildVersion=$(VERSION) \
+		  -X github.com/KuChainNetwork/kuchain/chain/constants.KuchainBuildBranch=$(BRANCH) \
+		  -X "github.com/KuChainNetwork/kuchain/chain/constants.KuchainBuildTime=$(TIME_BEGIN)" \
+		  -X github.com/KuChainNetwork/kuchain/chain/constants.KuchainBuildSDKVersion=$(SDK_PACK) \
 		  -X github.com/KuChainNetwork/kuchain/chain/constants/keys.ChainNameStr=$(CORE_SYMBOL) \
 		  -X github.com/KuChainNetwork/kuchain/chain/constants/keys.ChainMainNameStr=$(MAIN_SYMBOL)
 
@@ -67,7 +75,6 @@ ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
 BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)' -trimpath
-
 
 all: clear-build build
 

--- a/chain/constants/versions.go
+++ b/chain/constants/versions.go
@@ -1,30 +1,40 @@
 package constants
 
 import (
-	"strconv"
-
-	"github.com/KuChainNetwork/kuchain/chain/types"
 	"github.com/tendermint/tendermint/libs/log"
+	"gopkg.in/yaml.v2"
 )
-
-// some fix height
 
 var (
-	// FixAssetHeight fix asset bugs height
-	FixAssetHeight       string = ""
-	FixAssetHeightVal, _        = strconv.ParseInt(FixAssetHeight, 10, 64)
+	KuchainBuildVersion    = ""
+	KuchainBuildBranch     = ""
+	KuchainBuildTime       = ""
+	KuchainBuildSDKVersion = ""
 )
+
+// VersionInfo get Version Info
+func VersionInfo() []byte {
+	ver := struct {
+		Version    string `json:"version" yaml:"version"`
+		Branch     string `json:"branch" yaml:"branch"`
+		BuildTime  string `json:"build_time" yaml:"build_time"`
+		SDKVersion string `json:"sdk_version" yaml:"sdk_version"`
+	}{
+		Version:    KuchainBuildVersion,
+		Branch:     KuchainBuildBranch,
+		BuildTime:  KuchainBuildTime,
+		SDKVersion: KuchainBuildSDKVersion,
+	}
+
+	res, _ := yaml.Marshal(ver)
+	return res
+}
 
 // LogVersion log version info
 func LogVersion(logger log.Logger) {
-	logger.Info("FixAsset", "height", GetFixAssetHeight())
-}
-
-func GetFixAssetHeight() int64 {
-	return FixAssetHeightVal
-}
-
-// IsFixAssetHeight is fix asset
-func IsFixAssetHeight(ctx types.Context) bool {
-	return ctx.BlockHeight() > FixAssetHeightVal
+	logger.Info("Kuchain Version",
+		"version", KuchainBuildVersion,
+		"branch", KuchainBuildBranch,
+		"time", KuchainBuildTime,
+		"sdkVersion", KuchainBuildSDKVersion)
 }

--- a/cmd/kucd/cmd.go
+++ b/cmd/kucd/cmd.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/KuChainNetwork/kuchain/chain/constants"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	tversion "github.com/tendermint/tendermint/version"
+	"gopkg.in/yaml.v2"
 )
 
 // add server commands
@@ -37,4 +44,74 @@ func AddCommands(
 		flags.LineBreak,
 		version.Cmd,
 	)
+}
+
+const (
+	flagVersionSimple = "simple"
+	flagJSONFormat    = "json"
+)
+
+func versionCmd(ctx *server.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print kuchain version",
+		Long: `Print kuchain version numbers
+against which this app has been compiled.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var (
+				bs  []byte
+				err error
+			)
+
+			if !viper.GetBool(flagVersionSimple) {
+				vs := struct {
+					Name                string `json:"name" yaml:"name"`
+					Tendermint          string `json:"tendermint_version" yaml:"tendermint_version"`
+					ABCI                string `json:"abci" yaml:"abci"`
+					BlockProtocol       uint64 `json:"block_protocol" yaml:"block_protocol"`
+					P2PProtocol         uint64 `json:"p2p_protocol" yaml:"p2p_protocol"`
+					KuchainBuildVersion string `json:"version" yaml:"version"`
+					KuchainBuildBranch  string `json:"branch" yaml:"branch"`
+					KuchainBuildTime    string `json:"build_time" yaml:"build_time"`
+					SDKVersion          string `json:"sdk_version" yaml:"sdk_version"`
+					Commit              string `json:"commit" yaml:"commit"`
+					BuildTags           string `json:"build_tags" yaml:"build_tags"`
+				}{
+					Name:                version.Name,
+					Tendermint:          tversion.Version,
+					ABCI:                tversion.ABCIVersion,
+					BlockProtocol:       tversion.BlockProtocol.Uint64(),
+					P2PProtocol:         tversion.P2PProtocol.Uint64(),
+					KuchainBuildVersion: constants.KuchainBuildVersion,
+					KuchainBuildBranch:  constants.KuchainBuildBranch,
+					KuchainBuildTime:    constants.KuchainBuildTime,
+					SDKVersion:          constants.KuchainBuildSDKVersion,
+					Commit:              version.Commit,
+					BuildTags:           version.BuildTags,
+				}
+
+				if viper.GetBool(flagJSONFormat) {
+					bs, err = json.Marshal(&vs)
+				} else {
+					bs, err = yaml.Marshal(&vs)
+				}
+
+			} else {
+				bs = []byte(constants.KuchainBuildVersion)
+			}
+
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(bs))
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolP(flagVersionSimple, "s", false, "if just print simple version of kucd")
+	cmd.Flags().BoolP(flagJSONFormat, "j", false, "print version info by json")
+
+	return cmd
 }

--- a/cmd/kucd/main.go
+++ b/cmd/kucd/main.go
@@ -69,6 +69,8 @@ func main() {
 	rootCmd.AddCommand(replayCmd())
 	rootCmd.AddCommand(debug.Cmd(cdc))
 
+	rootCmd.AddCommand(versionCmd(ctx))
+
 	AddCommands(ctx, cdc, rootCmd, newApp, exportAppStateAndTMValidators)
 
 	// prepare and add flags


### PR DESCRIPTION
## Summary

Add version cmd to get build and version info for Kuchain.

## Introduction

We need get version info by kucd, so it can make us to use current version.

```bash
./build/kucd version -h     
Print kuchain version numbers
against which this app has been compiled.

Usage:
  kucd version [flags]

Flags:
  -h, --help     help for version
  -j, --json     print version info by json
  -s, --simple   if just print simple version of kucd
```

we can use `-s` to get a simple version info:

```bash
./build/kucd version -s
0.3.2-rc
```

or get all infos in yaml or json:

```bash
./build/kucd version   
name: kuchain
tendermint_version: 0.33.6
abci: 0.16.2
block_protocol: 10
p2p_protocol: 7
version: 0.3.2-rc
branch: features/get-version
build_time: 2020-08-19 03:39.27
sdk_version: github.com/cosmos/cosmos-sdk@v0.38.5
commit: 333ca3721dc045944d9d61ee1ba6dca301b8dd31
build_tags: netgo,ledger

./build/kucd version -j | jq
{
  "name": "kuchain",
  "tendermint_version": "0.33.6",
  "abci": "0.16.2",
  "block_protocol": 10,
  "p2p_protocol": 7,
  "version": "0.3.2-rc",
  "branch": "features/get-version",
  "build_time": "2020-08-19 03:39.27",
  "sdk_version": "github.com/cosmos/cosmos-sdk@v0.38.5",
  "commit": "333ca3721dc045944d9d61ee1ba6dca301b8dd31",
  "build_tags": "netgo,ledger"
}
```

## Modifys

- Add Build Infos in Makefiles
- Add Version cmd in kucd

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes