### PR TITLE
query validator by consaddr add

### DIFF
--- a/x/staking/client/rest/query.go
+++ b/x/staking/client/rest/query.go
@@ -106,6 +106,11 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 		paramsHandlerFn(cliCtx),
 	).Methods("GET")
 
+	r.HandleFunc(
+		"/staking/validator_consaddr/{consAddr}",
+		validatorByConsAddrHandlerFn(cliCtx),
+	).Methods("GET")
+
 }
 
 // HTTP request handler to query a delegator delegations
@@ -390,4 +395,9 @@ func paramsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		cliCtx = cliCtx.WithHeight(height)
 		rest.PostProcessResponse(w, cliCtx, res)
 	}
+}
+
+// HTTP request handler to query the validator information from a given validator address
+func validatorByConsAddrHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return queryValidatorByConsAddr(cliCtx, fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryValidatorByConsAddr))
 }

--- a/x/staking/client/rest/utils.go
+++ b/x/staking/client/rest/utils.go
@@ -151,3 +151,40 @@ func queryValidator(cliCtx context.CLIContext, endpoint string) http.HandlerFunc
 		rest.PostProcessResponse(w, cliCtx, res)
 	}
 }
+
+
+func queryValidatorByConsAddr(cliCtx context.CLIContext, endpoint string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		strConsAddr := vars["consAddr"]
+
+		// validatorAddr, err := sdk.ValAddressFromBech32(bech32validatorAddr)
+		// if err != nil {
+		// 	rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+		// 	return
+		// }
+		consAddr, _ := sdk.ConsAddressFromHex(strConsAddr)
+
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
+		params := types.NewQueryValidatorFromConsAddr(consAddr)
+
+		bz, err := cliCtx.Codec.MarshalJSON(params)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		res, height, err := cliCtx.QueryWithData(endpoint, bz)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		cliCtx = cliCtx.WithHeight(height)
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}

--- a/x/staking/types/querier.go
+++ b/x/staking/types/querier.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/KuChainNetwork/kuchain/chain/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // query endpoints supported by the staking Querier
@@ -21,6 +22,7 @@ const (
 	QueryPool                          = "pool"
 	QueryParameters                    = "parameters"
 	QueryHistoricalInfo                = "historicalInfo"
+	QueryValidatorByConsAddr           = "validatorByConsAddr"
 )
 
 // defines the params for the following queries:
@@ -107,4 +109,13 @@ type QueryHistoricalInfoParams struct {
 // NewQueryHistoricalInfoParams creates a new QueryHistoricalInfoParams instance
 func NewQueryHistoricalInfoParams(height int64) QueryHistoricalInfoParams {
 	return QueryHistoricalInfoParams{height}
+}
+
+
+type QueryValidatorFromConsAddr struct {
+	ConsAcc sdk.ConsAddress
+}
+
+func NewQueryValidatorFromConsAddr(consAcc sdk.ConsAddress) QueryValidatorFromConsAddr {
+	return QueryValidatorFromConsAddr{consAcc}
 }


### PR DESCRIPTION
## Summary

add function query validator by consAddr for rpc api

## Introduction

Since only the consAddr of the validator can be found in the block, adding this function allows the browser to obtain the corresponding validator's information based on the block information

## Modifys

add keeper function queryValidatorFromConsAddr 
add rest function queryValidatorByConsAddr

