### PR TITLE
delegation add systemaccount check

### DIFF
--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/KuChainNetwork/kuchain/chain/constants"
 	stakingexport "github.com/KuChainNetwork/kuchain/x/staking/exported"
 	"github.com/KuChainNetwork/kuchain/x/staking/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -170,6 +171,11 @@ func (k Keeper) IterateUnbondingDelegations(ctx sdk.Context, fn func(index int64
 func (k Keeper) HasMaxUnbondingDelegationEntries(ctx sdk.Context,
 	delegatorAddr AccountID, validatorAddr AccountID) bool {
 
+	name, ok := delegatorAddr.ToName()
+	if ok && constants.IsSystemAccount(name) {
+		return false
+	}
+
 	ubd, found := k.GetUnbondingDelegation(ctx, delegatorAddr, validatorAddr)
 	if !found {
 		return false
@@ -328,6 +334,10 @@ func (k Keeper) GetRedelegationsFromSrcValidator(ctx sdk.Context, valAddr Accoun
 func (k Keeper) HasReceivingRedelegation(ctx sdk.Context,
 	delAddr AccountID, valDstAddr AccountID) bool {
 
+	name, ok := delAddr.ToName()
+	if ok && constants.IsSystemAccount(name) {
+		return false
+	}
 	store := ctx.KVStore(k.storeKey)
 	prefix := types.GetREDsByDelToValDstIndexKey(delAddr, valDstAddr)
 	iterator := sdk.KVStorePrefixIterator(store, prefix)
@@ -340,6 +350,11 @@ func (k Keeper) HasReceivingRedelegation(ctx sdk.Context,
 func (k Keeper) HasMaxRedelegationEntries(ctx sdk.Context,
 	delegatorAddr AccountID, validatorSrcAddr,
 	validatorDstAddr AccountID) bool {
+
+	name, ok := delegatorAddr.ToName()
+	if ok && constants.IsSystemAccount(name) {
+		return false
+	}
 
 	red, found := k.GetRedelegation(ctx, delegatorAddr, validatorSrcAddr, validatorDstAddr)
 	if !found {


### PR DESCRIPTION
## Summary

add system account check in kustaking

## Introduction

system account can redelegate more times on srcvalidator to destvalidator,add system account check in kustaking

## Modifys

delegation.go 
HasMaxUnbondingDelegationEntries
HasReceivingRedelegation
HasMaxReDelegationEntries
add system account check

