### PR TITLE
Core token no check MaxSupply in issue

### DIFF
--- a/scripts/boot-testnet.py
+++ b/scripts/boot-testnet.py
@@ -125,7 +125,7 @@ def initGenesis(nodeNum):
 
    node(mainChainSymbol, 'genesis add-address %s' % (mainAuth))
    node(mainChainSymbol, 'genesis add-account %s %s' % (mainChainSymbol, mainAuth))
-   node(mainChainSymbol, 'genesis add-coin %s \"%s\"' % (coreCoin(1000000000000000000000000000000000000000), "main core"))
+   node(mainChainSymbol, 'genesis add-coin %s \"%s\"' % (coreCoin(0), "main core"))
    node(mainChainSymbol, 'genesis add-account-coin %s %s' % (mainAuth, coreCoin(100000000000000000000000000000000)))
    node(mainChainSymbol, 'genesis add-account-coin %s %s' % (mainChainSymbol, coreCoin(100000000000000000000000000000000)))
 

--- a/scripts/boot-testnet.sh
+++ b/scripts/boot-testnet.sh
@@ -35,7 +35,7 @@ printf "current val key ${VALKEY}\\n"
 ./build/kucd ${PARAMS} genesis add-account testacc1 ${TESTVALKEY}
 ./build/kucd ${PARAMS} genesis add-account testacc2 ${TESTVALKEY}
 ./build/kucd ${PARAMS} genesis add-address ${VALKEY}
-./build/kucd ${PARAMS} genesis add-coin "1000000000000000000000000000000000000000${MAIN_SYMBOL}/${CORE_SYMBOL}" "main token"
+./build/kucd ${PARAMS} genesis add-coin "0${MAIN_SYMBOL}/${CORE_SYMBOL}" "main token"
 #./build/kucd ${PARAMS} genesis add-coin "1000000000000000000000000000000000000000validatortoken" "for staking"
 ./build/kucd ${PARAMS} genesis add-account-coin ${VALKEY} "100000000000000000000000${MAIN_SYMBOL}/${CORE_SYMBOL}"
 ./build/kucd ${PARAMS} genesis add-account-coin ${MAIN_SYMBOL} "100000000000000000000000${MAIN_SYMBOL}/${CORE_SYMBOL}"

--- a/test/simapp/genesis.go
+++ b/test/simapp/genesis.go
@@ -70,6 +70,11 @@ func NewGenesisAccounts(rootAuth types.AccAddress, accounts ...SimGenesisAccount
 		}
 		max := types.NewInt(1000000000000000000) // for default
 		max = max.Mul(types.NewInt(1000000000000000000))
+
+		if c.Denom == constants.DefaultBondDenom {
+			max = types.NewInt(0)
+		}
+
 		res.coins = append(res.coins, assetTypes.NewGenesisCoin(createor, symbol, max, fmt.Sprintf("desc for %s", c.Denom)))
 	}
 

--- a/x/asset/handler_test.go
+++ b/x/asset/handler_test.go
@@ -245,6 +245,30 @@ func TestIssueCoins(t *testing.T) {
 	})
 }
 
+func TestIssueMaxSupplyCoreCoin(t *testing.T) {
+	app, _ := createAppForTest()
+
+	Convey("test core coins no limit by max supply", t, func() {
+		ctx := app.NewTestContext()
+		stat, err := app.AssetKeeper().GetCoinStat(ctx, constants.ChainMainName, constants.DefaultBondSymbolName)
+		So(err, ShouldBeNil)
+
+		So(stat.GetCurrentMaxSupplyLimit(111).IsZero(), ShouldBeTrue)
+		So(stat.MaxSupply.IsZero(), ShouldBeTrue)
+
+		simapp.AfterBlockCommitted(app, 1)
+
+		ctx = app.NewTestContext()
+		statNew, err := app.AssetKeeper().GetCoinStat(ctx, constants.ChainMainName, constants.DefaultBondSymbolName)
+		So(err, ShouldBeNil)
+
+		So(statNew.GetCurrentMaxSupplyLimit(111).IsZero(), ShouldBeTrue)
+		So(statNew.MaxSupply.IsZero(), ShouldBeTrue)
+		So(statNew.Supply.IsGTE(stat.Supply), ShouldBeTrue)
+		So(statNew.Supply.IsZero(), ShouldBeFalse)
+	})
+}
+
 func TestIssueMaxSupply(t *testing.T) {
 	app, _ := createAppForTest()
 	Convey("test issue coins cannot > max supply", t, func() {
@@ -334,7 +358,6 @@ func TestIssueIsCanIssueTag(t *testing.T) {
 		So(issueCoin(t, app, false, account4, symbol, issueAmt),
 			simapp.ShouldErrIs, assetTypes.ErrAssetCoinCannotBeIssue) // after IssueCoinsWaitBlockNums - 1 block, can issue
 		simapp.CheckBalance(t, app, account4, amt)
-
 	})
 }
 

--- a/x/asset/keeper/keeper_internal.go
+++ b/x/asset/keeper/keeper_internal.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"github.com/KuChainNetwork/kuchain/chain/constants"
 	"github.com/KuChainNetwork/kuchain/chain/types/coin"
 	"github.com/KuChainNetwork/kuchain/x/asset/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -42,7 +43,8 @@ func (a AssetKeeper) issueCoinStat(ctx sdk.Context, amount types.Coin) error {
 	maxSupply := stat.GetCurrentMaxSupplyLimit(ctx.BlockHeight())
 	ctx.Logger().Debug("update state", "newSupply", newSupply, "maxSupply", stat.MaxSupply, "limit", maxSupply)
 
-	if !maxSupply.IsGTE(newSupply) {
+	// Core token no limit
+	if (amount.Denom != constants.DefaultBondDenom) && (!maxSupply.IsGTE(newSupply)) {
 		return types.ErrAssetIssueGTMaxSupply
 	}
 

--- a/x/asset/types/errors.go
+++ b/x/asset/types/errors.go
@@ -25,4 +25,5 @@ var (
 	ErrAssetSymbolError                      = sdkerrors.Register(ModuleName, 20, "asset symbol error")
 	ErrAssetCoinNoZero                       = sdkerrors.Register(ModuleName, 21, "amount should not be zero")
 	ErrAssetCoinCannotBeBurn                 = sdkerrors.Register(ModuleName, 22, "coin state not allowed burn")
+	ErrAssetIssueMaxSupplyShouldNoZero       = sdkerrors.Register(ModuleName, 23, "issue max supply should not be zero")
 )

--- a/x/asset/types/genesis.go
+++ b/x/asset/types/genesis.go
@@ -98,10 +98,6 @@ func NewGenesisCoin(creator, symbol Name, maxSupplyAmount Int, description strin
 
 // Validate imp GenesisCoin
 func (g BaseGensisAssetCoin) Validate() error {
-	if g.MaxSupply.IsZero() {
-		return fmt.Errorf("genesis max supply coin cannot be zero")
-	}
-
 	if len(g.Description) >= MaxDescriptionLength {
 		return fmt.Errorf("genesis coin description too length")
 	}

--- a/x/asset/types/msgs.go
+++ b/x/asset/types/msgs.go
@@ -120,6 +120,11 @@ func (msg MsgCreateCoin) ValidateBasic() error {
 		return ErrAssetSymbolError
 	}
 
+	// current version no allow create coins max_supply with 0
+	if data.MaxSupply.IsZero() {
+		return ErrAssetIssueMaxSupplyShouldNoZero
+	}
+
 	if err := CheckCoinStatOpts(
 		0, // no check this
 		data.CanIssue, data.CanLock,


### PR DESCRIPTION
## Summary

Core token no check MaxSupply in issue.

## Introduction

In Kratos the core token will mint each block and it should be unlimited, so issue should no check MaxSupply for it.

In next version user can create token with no maxsupply to limit by set maxsupply zero, but in this version user cannot do it.

## Modifys

- no check maxsupply in issue stat for core token
- core token maxsupply should be zero
- issue msg not allow maxsupply be zero
- add tests

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes