### PR TITLE
Add Test Support For Dex Module

### DIFF
--- a/chain/types/interfaces.go
+++ b/chain/types/interfaces.go
@@ -26,7 +26,6 @@ type KuTransfMsg interface {
 	GetSignBytes() []byte
 	GetSigners() []AccAddress
 	GetTransfers() []KuMsgTransfer
-	GetData() []byte
 	ValidateTransfer() error
 }
 

--- a/test/simapp/app.go
+++ b/test/simapp/app.go
@@ -423,6 +423,10 @@ func (app *SimApp) GovKeeper() *gov.Keeper {
 	return &app.govKeeper
 }
 
+func (app *SimApp) DexKeeper() *dex.Keeper {
+	return &app.dexKeeper
+}
+
 // GetMaccPerms returns a copy of the module account permissions
 func GetMaccPerms() map[string][]string {
 	dupMaccPerms := make(map[string][]string)

--- a/x/dex/dex_test.go
+++ b/x/dex/dex_test.go
@@ -1,0 +1,59 @@
+package dex_test
+
+import (
+	"testing"
+
+	"github.com/KuChainNetwork/kuchain/chain/constants"
+	"github.com/KuChainNetwork/kuchain/chain/types"
+	"github.com/KuChainNetwork/kuchain/test/simapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+var (
+	// values for test
+	wallet      = simapp.NewWallet()
+	addr1       = wallet.NewAccAddressByName(name1)
+	addr2       = wallet.NewAccAddressByName(name2)
+	addr3       = wallet.NewAccAddressByName(name3)
+	addr4       = wallet.NewAccAddressByName(name4)
+	addr5       = wallet.NewAccAddressByName(name5)
+	name1       = types.MustName("test01@chain")
+	name2       = types.MustName("aaaeeebbbccc")
+	name3       = types.MustName("aaaeeebbbcc2")
+	name4       = types.MustName("test")
+	name5       = types.MustName("foo")
+	account1    = types.NewAccountIDFromName(name1)
+	account2    = types.NewAccountIDFromName(name2)
+	account3    = types.NewAccountIDFromName(name3)
+	account4    = types.NewAccountIDFromName(name4)
+	account5    = types.NewAccountIDFromName(name5)
+	addAccount1 = types.NewAccountIDFromAccAdd(addr1)
+)
+
+func createAppForTest() (*simapp.SimApp, sdk.Context) {
+	asset1 := types.NewCoins(
+		types.NewInt64Coin("foo/coin", 10000000),
+		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000))
+	asset2 := types.NewCoins(
+		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000))
+	asset3 := types.NewCoins(
+		types.NewInt64Coin("foo/coin", 100),
+		types.NewInt64Coin(constants.DefaultBondDenom, 10000000000))
+
+	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(),
+		simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1),
+		simapp.NewSimGenesisAccount(account2, addr2).WithAsset(asset2),
+		simapp.NewSimGenesisAccount(account3, addr3).WithAsset(asset3),
+		simapp.NewSimGenesisAccount(account4, addr4).WithAsset(asset2),
+		simapp.NewSimGenesisAccount(account5, addr5).WithAsset(asset2),
+	)
+	app := simapp.SetupWithGenesisAccounts(genAccs)
+
+	ctxCheck := app.BaseApp.NewContext(true, abci.Header{Height: app.LastBlockHeight() + 1})
+	return app, ctxCheck
+}
+
+func transfer(t *testing.T, app *simapp.SimApp, isSuccess bool, from, to types.AccountID, amt types.Coins, payer types.AccountID) error {
+	return simapp.CommitTransferTx(t, app, wallet, isSuccess, from, to, amt, payer)
+}

--- a/x/dex/handler.go
+++ b/x/dex/handler.go
@@ -41,9 +41,12 @@ func handleMsgCreateDex(ctx chainTypes.Context, k Keeper, msg *types.MsgCreateDe
 		"desc", string(msgData.Desc))
 
 	ctx.RequireAccount(msgData.Creator)
+
+	/* no need check, has check by ValiteBasic
 	if err := ctx.RequireTransfer(types.ModuleAccountID, msgData.Stakings); err != nil {
 		return nil, errors.Wrapf(err, "msg create dex error no transfer")
 	}
+	*/
 
 	if err := k.CreateDex(ctx.Context(),
 		msgData.Creator, msgData.Stakings, string(msgData.Desc)); err != nil {

--- a/x/dex/handler_test.go
+++ b/x/dex/handler_test.go
@@ -1,0 +1,42 @@
+package dex_test
+
+import (
+	"testing"
+
+	"github.com/KuChainNetwork/kuchain/chain/types"
+	"github.com/KuChainNetwork/kuchain/test/simapp"
+	dexTypes "github.com/KuChainNetwork/kuchain/x/dex/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestHandleCreateDex(t *testing.T) {
+	app, _ := createAppForTest()
+
+	Convey("test create dex", t, func() {
+		ctx := app.NewTestContext()
+
+		var (
+			acc     = account5
+			accName = name5
+			auth    = wallet.GetAuth(acc)
+		)
+
+		msg := dexTypes.NewMsgCreateDex(
+			auth,
+			accName,
+			types.NewInt64CoreCoins(1000000),
+			[]byte("dex for test"))
+
+		So(msg.ValidateBasic(), ShouldBeNil)
+
+		tx := simapp.NewTxForTest(
+			acc,
+			[]sdk.Msg{
+				&msg,
+			}, wallet.PrivKey(auth))
+
+		err := simapp.CheckTxs(t, app, ctx, tx)
+		So(err, ShouldBeNil)
+	})
+}

--- a/x/dex/handler_test.go
+++ b/x/dex/handler_test.go
@@ -10,6 +10,38 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+func CreateDexForTest(t *testing.T, app *simapp.SimApp, wallet *simapp.Wallet, isSuccess bool, account types.AccountID, stakings types.Coins, desc []byte) error {
+	ctx := app.NewTestContext()
+
+	var (
+		acc     = account
+		accName = account.MustName()
+		auth    = wallet.GetAuth(acc)
+	)
+
+	msg := dexTypes.NewMsgCreateDex(
+		auth,
+		accName,
+		stakings,
+		desc)
+
+	if err := msg.ValidateBasic(); err != nil {
+		return err
+	}
+
+	tx := simapp.NewTxForTest(
+		acc,
+		[]sdk.Msg{
+			&msg,
+		}, wallet.PrivKey(auth))
+
+	if !isSuccess {
+		tx = tx.WithCannotPass()
+	}
+
+	return simapp.CheckTxs(t, app, ctx, tx)
+}
+
 func TestHandleCreateDex(t *testing.T) {
 	app, _ := createAppForTest()
 
@@ -38,5 +70,139 @@ func TestHandleCreateDex(t *testing.T) {
 
 		err := simapp.CheckTxs(t, app, ctx, tx)
 		So(err, ShouldBeNil)
+	})
+
+	Convey("test transfer no enough", t, func() {
+		ctx := app.NewTestContext()
+
+		var (
+			acc     = account4
+			accName = name4
+			auth    = wallet.GetAuth(acc)
+		)
+
+		msg := dexTypes.NewMsgCreateDex(
+			auth,
+			accName,
+			types.NewInt64CoreCoins(1000000),
+			[]byte("dex for test"))
+
+		msg.Transfers[0].Amount[0].Amount = types.NewInt(111)
+
+		So(msg.ValidateBasic(), simapp.ShouldErrIs, types.ErrKuMsgFromNotEqual)
+
+		tx := simapp.NewTxForTest(
+			acc,
+			[]sdk.Msg{
+				&msg,
+			}, wallet.PrivKey(auth)).WithCannotPass()
+
+		err := simapp.CheckTxs(t, app, ctx, tx)
+		So(err, simapp.ShouldErrIs, types.ErrKuMsgFromNotEqual)
+	})
+
+	Convey("test transfer no module", t, func() {
+		ctx := app.NewTestContext()
+
+		var (
+			acc     = account4
+			accName = name4
+			auth    = wallet.GetAuth(acc)
+		)
+
+		msg := dexTypes.NewMsgCreateDex(
+			auth,
+			accName,
+			types.NewInt64CoreCoins(1000000),
+			[]byte("dex for test"))
+
+		msg.Transfers[0].To = acc
+
+		So(msg.ValidateBasic(), simapp.ShouldErrIs, types.ErrKuMsgFromNotEqual)
+
+		tx := simapp.NewTxForTest(
+			acc,
+			[]sdk.Msg{
+				&msg,
+			}, wallet.PrivKey(auth)).WithCannotPass()
+
+		err := simapp.CheckTxs(t, app, ctx, tx)
+		So(err, simapp.ShouldErrIs, types.ErrKuMsgFromNotEqual)
+	})
+
+	Convey("test transfer from error", t, func() {
+		ctx := app.NewTestContext()
+
+		var (
+			acc     = account4
+			accName = name4
+			auth    = wallet.GetAuth(acc)
+		)
+
+		msg := dexTypes.NewMsgCreateDex(
+			auth,
+			accName,
+			types.NewInt64CoreCoins(1000000),
+			[]byte("dex for test"))
+
+		msg.Transfers[0].From = account5
+
+		So(msg.ValidateBasic(), simapp.ShouldErrIs, types.ErrKuMsgFromNotEqual)
+
+		tx := simapp.NewTxForTest(
+			acc,
+			[]sdk.Msg{
+				&msg,
+			}, wallet.PrivKey(auth)).WithCannotPass()
+
+		err := simapp.CheckTxs(t, app, ctx, tx)
+		So(err, simapp.ShouldErrIs, types.ErrKuMsgFromNotEqual)
+	})
+
+	Convey("test transfer desc too long", t, func() {
+		So(CreateDexForTest(t, app, wallet,
+			false,
+			account4, types.NewInt64CoreCoins(111),
+			make([]byte, 520)), simapp.ShouldErrIs, dexTypes.ErrDexDescTooLong)
+	})
+
+	Convey("test transfer create two times", t, func() {
+		So(CreateDexForTest(t, app, wallet,
+			false,
+			account5, types.NewInt64CoreCoins(111),
+			[]byte("hello")), simapp.ShouldErrIs, dexTypes.ErrDexHadCreated)
+	})
+}
+
+func TestHandleCreateDexNumber(t *testing.T) {
+	app, _ := createAppForTest()
+
+	Convey("test create dex number", t, func() {
+		So(CreateDexForTest(t, app, wallet,
+			true,
+			account4, types.NewInt64CoreCoins(111),
+			[]byte("account4")), ShouldBeNil)
+
+		So(CreateDexForTest(t, app, wallet,
+			true,
+			account5, types.NewInt64CoreCoins(111),
+			[]byte("account5")), ShouldBeNil)
+
+		simapp.AfterBlockCommitted(app, 1)
+
+		ctx := app.NewTestContext()
+		dex1, ok := app.DexKeeper().GetDex(ctx, name4)
+
+		So(dex1, ShouldNotBeNil)
+		So(ok, ShouldBeTrue)
+		So(dex1.Creator, simapp.ShouldEq, name4)
+		So(dex1.Number, ShouldEqual, 0)
+
+		dex2, ok := app.DexKeeper().GetDex(ctx, name5)
+
+		So(dex2, ShouldNotBeNil)
+		So(ok, ShouldBeTrue)
+		So(dex2.Creator, simapp.ShouldEq, name5)
+		So(dex2.Number, ShouldEqual, 1)
 	})
 }

--- a/x/dex/keeper/keeper.go
+++ b/x/dex/keeper/keeper.go
@@ -30,3 +30,8 @@ func NewDexKeeper(cdc *codec.Codec, key sdk.StoreKey) DexKeeper {
 func (ak DexKeeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
+
+// GetDex get dex data, if no found, return false
+func (a DexKeeper) GetDex(ctx sdk.Context, creator types.Name) (*types.Dex, bool) {
+	return a.getDex(ctx, creator)
+}

--- a/x/dex/types/msgs.go
+++ b/x/dex/types/msgs.go
@@ -6,6 +6,10 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+var (
+	_ types.KuTransfMsg = &MsgCreateDex{}
+)
+
 // MsgCreateDex msg for create dex
 type MsgCreateDex struct {
 	types.KuMsg


### PR DESCRIPTION
## Summary

add test support for dex module.

## Introduction

simApp need support dex module. add a test for create dex msg.

## Modifys

- add api to simapp for dex module.
- fix kuTransferMsg interface, del useless api.
- add a test for create dex msg.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes