### PR TITLE
Add Init supply check in create asset

### DIFF
--- a/chain/types/coin.go
+++ b/chain/types/coin.go
@@ -79,10 +79,22 @@ func CoinAccountsFromDenom(denom string) (Name, Name, error) {
 	return creator, symbol, nil
 }
 
+// NewInt64CoreCoin create a default bond denom coin amount by int64 amt
 func NewInt64CoreCoin(amt int64) Coin {
 	return NewCoin(keys.DefaultBondDenom, NewInt(amt))
 }
 
+// NewInt64CoreCoins create a default bond denom coins type amount by int64 amt
 func NewInt64CoreCoins(amt int64) Coins {
 	return Coins{NewInt64CoreCoin(amt)}
+}
+
+// NewIntCoreCoin create a default bond denom coin amount by Int amt
+func NewIntCoreCoin(val Int) Coin {
+	return NewCoin(keys.DefaultBondDenom, val)
+}
+
+// NewIntCoreCoins create a default bond denom coins type amount by Int amt
+func NewIntCoreCoins(val Int) Coins {
+	return Coins{NewIntCoreCoin(val)}
 }

--- a/x/asset/handler_test.go
+++ b/x/asset/handler_test.go
@@ -123,6 +123,20 @@ func TestCreateAsset(t *testing.T) {
 			simapp.ShouldErrIs, assetTypes.ErrAssetDescriptorTooLarge)
 	})
 
+	Convey("test create asset init supply too large", t, func() {
+		// create in last test
+		var (
+			symbol     = types.MustName("abcd")
+			demon      = types.CoinDenom(name4, symbol)
+			maxSupply  = types.NewCoin(demon, types.NewInt(10000000000000))
+			initSupply = types.NewCoin(demon, types.NewInt(10000000000001))
+			desc       = []byte(make([]byte, 1))
+		)
+
+		So(createCoinExt(t, app, false, account4, symbol, maxSupply, true, true, true, 100000, initSupply, desc),
+			simapp.ShouldErrIs, assetTypes.ErrAssetCoinMustSupplyNeedGTInitSupply)
+	})
+
 	Convey("test create symbol error asset", t, func() {
 		var (
 			symbol        = types.MustName("abc")
@@ -147,8 +161,6 @@ func TestCreateAsset(t *testing.T) {
 			simapp.ShouldErrIs, assetTypes.ErrAssetSymbolError)
 	})
 }
-
-// TODO: add coin stat setOpt test
 
 func TestIssueCoins(t *testing.T) {
 	app, _ := createAppForTest()

--- a/x/asset/types/coin.go
+++ b/x/asset/types/coin.go
@@ -81,6 +81,11 @@ func CheckCoinStatOpts(createHeight int64, canIssue, canLock bool, issue2Height 
 			return ErrAssetIssueToHeightMustGTCurrentHeight
 		}
 	}
+
+	if !(init.IsZero() || max.IsGTE(init)) {
+		return ErrAssetMaxSupplyShouldGTEInitSupply
+	}
+
 	return nil
 }
 

--- a/x/asset/types/errors.go
+++ b/x/asset/types/errors.go
@@ -26,4 +26,5 @@ var (
 	ErrAssetCoinNoZero                       = sdkerrors.Register(ModuleName, 21, "amount should not be zero")
 	ErrAssetCoinCannotBeBurn                 = sdkerrors.Register(ModuleName, 22, "coin state not allowed burn")
 	ErrAssetIssueMaxSupplyShouldNoZero       = sdkerrors.Register(ModuleName, 23, "issue max supply should not be zero")
+	ErrAssetMaxSupplyShouldGTEInitSupply     = sdkerrors.Register(ModuleName, 24, "max supply should be greater than init supply")
 )

--- a/x/distribution/keeper/keeper_test.go
+++ b/x/distribution/keeper/keeper_test.go
@@ -45,15 +45,17 @@ func TestWithdrawValidatorCommission1(t *testing.T) {
 	intNum, _ := sdk.NewIntFromString("100000000000000000000")
 	intNumMax, _ := sdk.NewIntFromString("300000000000000000000")
 
-	ask.Create(ctx, MasterName, myTokenName, assettypes.NewCoin(tCoins, intNum),
-		true, true, true, 0, assettypes.NewCoin(tCoins, intNumMax), []byte("mytoken"))
+	err := ask.Create(ctx, MasterName, myTokenName, assettypes.NewCoin(tCoins, intNumMax),
+		true, true, true, 0, chainType.NewCoin(tCoins, chainType.NewInt(0)), []byte("mytoken"))
+	require.Nil(t, err)
 
-	ask.Create(ctx, MasterName, myStakeName, assettypes.NewCoin(sCoins, intNum),
-		true, true, true, 0, assettypes.NewCoin(sCoins, intNumMax), []byte("stake"))
+	err = ask.Create(ctx, MasterName, myStakeName, assettypes.NewCoin(sCoins, intNum),
+		true, true, true, 0, chainType.NewCoin(sCoins, chainType.NewInt(0)), []byte("stake"))
+	require.Nil(t, err)
 
 	intNum0, _ := sdk.NewIntFromString("100033333333333333")
 	myTokenCoins := assettypes.Coins{assettypes.NewCoin(tCoins, intNum0)}
-	_, err := ask.IssueCoinPower(ctx, Master, myTokenCoins)
+	_, err = ask.IssueCoinPower(ctx, Master, myTokenCoins)
 	require.Nil(t, err)
 
 	stakeCoins := assettypes.Coins{assettypes.NewCoin(sCoins, intNum0)}
@@ -136,18 +138,19 @@ func TestWithdrawValidatorCommission2(t *testing.T) {
 
 	ctx, _, keeper, _, supplyKeeper, ask := CreateTestInputDefault(t, false, 1000)
 
-	intNum, _ := sdk.NewIntFromString("100000000000000000000")
 	intNumMax, _ := sdk.NewIntFromString("300000000000000000000")
 
-	ask.Create(ctx, MasterName, myTokenName, assettypes.NewCoin(tCoins, intNum),
-		true, true, true, 0, assettypes.NewCoin(tCoins, intNumMax), []byte("mytoken"))
+	err := ask.Create(ctx, MasterName, myTokenName, assettypes.NewCoin(tCoins, intNumMax),
+		true, true, true, 0, assettypes.NewCoin(tCoins, chainType.NewInt(0)), []byte("mytoken"))
+	require.Nil(t, err)
 
-	ask.Create(ctx, MasterName, myStakeName, assettypes.NewCoin(sCoins, intNum),
-		true, true, true, 0, assettypes.NewCoin(sCoins, intNumMax), []byte("stake"))
+	err = ask.Create(ctx, MasterName, myStakeName, assettypes.NewCoin(sCoins, intNumMax),
+		true, true, true, 0, assettypes.NewCoin(sCoins, chainType.NewInt(0)), []byte("stake"))
+	require.Nil(t, err)
 
 	intNum0, _ := sdk.NewIntFromString("100033333333333333")
 	TokenCoins := assettypes.Coins{assettypes.NewCoin(tCoins, intNum0)}
-	_, err := ask.IssueCoinPower(ctx, Master, TokenCoins)
+	_, err = ask.IssueCoinPower(ctx, Master, TokenCoins)
 	require.Nil(t, err)
 
 	StakeCoins := assettypes.Coins{assettypes.NewCoin(sCoins, intNum0)}
@@ -232,14 +235,15 @@ func TestGetTotalRewards(t *testing.T) {
 
 	ctx, _, keeper, _, supplyKeeper, ask := CreateTestInputDefault(t, false, 1000)
 
-	intNum, _ := sdk.NewIntFromString("100000000000000000000")
 	intNumMax, _ := sdk.NewIntFromString("300000000000000000000")
 
-	ask.Create(ctx, MasterName, myTokenName, assettypes.NewCoin(tCoins, intNum),
-		true, true, true, 0, assettypes.NewCoin(tCoins, intNumMax), []byte("mytoken"))
+	err := ask.Create(ctx, MasterName, myTokenName, assettypes.NewCoin(tCoins, intNumMax),
+		true, true, true, 0, assettypes.NewCoin(tCoins, chainType.NewInt(0)), []byte("mytoken"))
+	require.Nil(t, err)
 
-	ask.Create(ctx, MasterName, myStakeName, assettypes.NewCoin(sCoins, intNum),
-		true, true, true, 0, assettypes.NewCoin(sCoins, intNumMax), []byte("stake"))
+	err = ask.Create(ctx, MasterName, myStakeName, assettypes.NewCoin(sCoins, intNumMax),
+		true, true, true, 0, assettypes.NewCoin(sCoins, chainType.NewInt(0)), []byte("stake"))
+	require.Nil(t, err)
 
 	{
 		intNum0, _ := sdk.NewIntFromString("100033333333333333")
@@ -258,7 +262,7 @@ func TestGetTotalRewards(t *testing.T) {
 	myTokenCoins := assettypes.Coins{{Denom: tCoins, Amount: sdk.NewInt(int64(800000000))}}
 	stakeCoins := assettypes.Coins{{Denom: sCoins, Amount: sdk.NewInt(int64(600000000))}}
 
-	err := supplyKeeper.SendCoinsFromAccountToModule(ctx, Master, distrAcc.GetID().String(), myTokenCoins)
+	err = supplyKeeper.SendCoinsFromAccountToModule(ctx, Master, distrAcc.GetID().String(), myTokenCoins)
 	require.Nil(t, err)
 
 	err = supplyKeeper.SendCoinsFromAccountToModule(ctx, Master, distrAcc.GetID().String(), stakeCoins)

--- a/x/genutil/client/cli/gentx_test.go
+++ b/x/genutil/client/cli/gentx_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"testing"
+
 	"github.com/KuChainNetwork/kuchain/chain/config"
 	"github.com/KuChainNetwork/kuchain/test/simapp"
 	"github.com/KuChainNetwork/kuchain/x/asset"
@@ -14,12 +16,14 @@ import (
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
-	"testing"
 )
 
 func TestGenTxCmdCmd(t *testing.T) {
 	Convey("TestGenTxCmdCmd", t, func() {
 		cmd := &cobra.Command{}
+
+		wallet := simapp.NewWallet()
+		key := wallet.NewAccAddress()
 
 		SetupViper()
 		keysHome, cleanup := simapp.NewTestCaseDir(t)
@@ -47,7 +51,7 @@ func TestGenTxCmdCmd(t *testing.T) {
 
 		gentxCmd := GenTxCmd(ctx, cdc, simapp.ModuleBasics, staking.AppModuleBasic{}, asset.GenesisBalancesIterator{},
 			home, keysHome, staking.NewFuncManager())
-		err = gentxCmd.RunE(cmd, []string{"moniker"})
+		err = gentxCmd.RunE(cmd, []string{"moniker", key.String()})
 		So(err, ShouldBeNil)
 	})
 }

--- a/x/supply/keeper/querier_test.go
+++ b/x/supply/keeper/querier_test.go
@@ -2,46 +2,37 @@ package keeper_test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/KuChainNetwork/kuchain/chain/constants"
 	chainType "github.com/KuChainNetwork/kuchain/chain/types"
 	"github.com/KuChainNetwork/kuchain/x/asset"
 	assettypes "github.com/KuChainNetwork/kuchain/x/asset/types"
+	keep "github.com/KuChainNetwork/kuchain/x/supply/keeper"
 	"github.com/KuChainNetwork/kuchain/x/supply/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
-
-	//"github.com/stretchr/testify/require"
-	//abci "github.com/tendermint/tendermint/abci/types"
-
-	keep "github.com/KuChainNetwork/kuchain/x/supply/keeper"
-	//"github.com/KuChainNetwork/kuchain/x/supply/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func initCoin(t *testing.T, ctx sdk.Context, assetKeeper asset.Keeper, coin chainType.Coin, id chainType.AccountID) {
-
-	intNum, _ := sdk.NewIntFromString("80000000000000000000000")
 	intMaxNum, _ := sdk.NewIntFromString("100000000000000000000000")
 
-	TestMaster := constants.ChainMainNameStr
-	MasterName, _ := chainType.NewName(TestMaster)
-	Master := chainType.NewAccountIDFromName(MasterName)
+	denom := coin.Denom
+	creater, symbol, err := chainType.CoinAccountsFromDenom(denom)
+	So(err, ShouldBeNil)
 
-	Symbol := strings.Split(coin.Denom, "/")
-	SymbolName, _ := chainType.NewName(Symbol[1])
+	err = assetKeeper.Create(ctx, creater, symbol, chainType.NewCoin(denom, intMaxNum),
+		true, true, true, 0, chainType.NewInt64CoreCoin(0), []byte("create"))
+	So(err, ShouldBeNil)
 
-	assetKeeper.Create(ctx, MasterName, SymbolName, assettypes.NewCoin(coin.Denom, intNum),
-		true, true, true, 0, assettypes.NewCoin(coin.Denom, intMaxNum), []byte("create"))
+	err = assetKeeper.Issue(ctx, creater, symbol, assettypes.NewCoin(coin.Denom, coin.Amount))
+	So(err, ShouldBeNil)
 
-	assetKeeper.Issue(ctx, MasterName, SymbolName, assettypes.NewCoin(coin.Denom, coin.Amount))
-
-	Coins := chainType.NewCoins(chainType.NewCoin(coin.Denom, coin.Amount))
-	err := assetKeeper.Transfer(ctx, Master, id, Coins)
-	require.Nil(t, err)
-
+	Coins := chainType.NewCoins(coin)
+	err = assetKeeper.Transfer(ctx, chainType.NewAccountIDFromName(creater), id, Coins)
+	So(err, ShouldBeNil)
 }
 
 func fInitCoins(t *testing.T, ctx sdk.Context, ask asset.Keeper, coins chainType.Coins, id chainType.AccountID) {
@@ -55,46 +46,49 @@ func TestNewQuerier(t *testing.T) {
 	keeper := app.SupplyKeeper()
 	cdc := app.Codec()
 
-	supplyCoins := chainType.NewCoins(
-		chainType.NewCoin(constants.DefaultBondDenom, sdk.NewInt(100)),
-		chainType.NewCoin(constants.ChainMainNameStr+"/"+"photon", sdk.NewInt(50)),
-		chainType.NewCoin(constants.ChainMainNameStr+"/"+"atom", sdk.NewInt(2000)),
-		chainType.NewCoin(constants.ChainMainNameStr+"/"+"btc", sdk.NewInt(21000000)),
-	)
+	Convey("test new query", t, func() {
 
-	supplyAcc := keeper.GetModuleAccount(ctx, types.ModuleName).GetID()
-	fInitCoins(t, ctx, *app.AssetKeeper(), supplyCoins, supplyAcc)
+		supplyCoins := chainType.NewCoins(
+			chainType.NewCoin(constants.DefaultBondDenom, sdk.NewInt(100)),
+			chainType.NewCoin(constants.ChainMainNameStr+"/"+"photon", sdk.NewInt(50)),
+			chainType.NewCoin(constants.ChainMainNameStr+"/"+"atom", sdk.NewInt(2000)),
+			chainType.NewCoin(constants.ChainMainNameStr+"/"+"btc", sdk.NewInt(21000000)),
+		)
 
-	query := abci.RequestQuery{
-		Path: "",
-		Data: []byte{},
-	}
-	//
-	querier := keep.NewQuerier(*keeper)
+		supplyAcc := keeper.GetModuleAccount(ctx, types.ModuleName).GetID()
+		fInitCoins(t, ctx, *app.AssetKeeper(), supplyCoins, supplyAcc)
 
-	bz, err := querier(ctx, []string{"other"}, query)
-	require.Error(t, err)
-	require.Nil(t, bz)
+		query := abci.RequestQuery{
+			Path: "",
+			Data: []byte{},
+		}
+		//
+		querier := keep.NewQuerier(*keeper)
 
-	queryTotalSupplyParams := types.NewQueryTotalSupplyParams(1, 20)
-	bz, errRes := cdc.MarshalJSON(queryTotalSupplyParams)
-	require.Nil(t, errRes)
+		bz, err := querier(ctx, []string{"other"}, query)
+		require.Error(t, err)
+		require.Nil(t, bz)
 
-	query.Path = fmt.Sprintf("/custom/supply/%s", types.QueryTotalSupply)
-	query.Data = bz
+		queryTotalSupplyParams := types.NewQueryTotalSupplyParams(1, 20)
+		bz, errRes := cdc.MarshalJSON(queryTotalSupplyParams)
+		require.Nil(t, errRes)
 
-	_, err = querier(ctx, []string{types.QueryTotalSupply}, query)
-	require.Nil(t, err)
+		query.Path = fmt.Sprintf("/custom/supply/%s", types.QueryTotalSupply)
+		query.Data = bz
 
-	querySupplyParams := types.NewQuerySupplyOfParams(constants.DefaultBondDenom)
-	bz, errRes = cdc.MarshalJSON(querySupplyParams)
-	require.Nil(t, errRes)
+		_, err = querier(ctx, []string{types.QueryTotalSupply}, query)
+		require.Nil(t, err)
 
-	query.Path = fmt.Sprintf("/custom/supply/%s", types.QuerySupplyOf)
-	query.Data = bz
+		querySupplyParams := types.NewQuerySupplyOfParams(constants.DefaultBondDenom)
+		bz, errRes = cdc.MarshalJSON(querySupplyParams)
+		require.Nil(t, errRes)
 
-	_, err = querier(ctx, []string{types.QuerySupplyOf}, query)
-	require.Nil(t, err)
+		query.Path = fmt.Sprintf("/custom/supply/%s", types.QuerySupplyOf)
+		query.Data = bz
+
+		_, err = querier(ctx, []string{types.QuerySupplyOf}, query)
+		require.Nil(t, err)
+	})
 }
 
 func TestQuerySupply(t *testing.T) {
@@ -102,52 +96,56 @@ func TestQuerySupply(t *testing.T) {
 	keeper := *app.SupplyKeeper()
 	cdc := app.Codec()
 
-	supplyCoins := chainType.NewCoins(
-		chainType.NewCoin(constants.DefaultBondDenom, sdk.NewInt(100)),
-		chainType.NewCoin(constants.ChainMainNameStr+"/"+"photon", sdk.NewInt(50)),
-		chainType.NewCoin(constants.ChainMainNameStr+"/"+"atom", sdk.NewInt(2000)),
-		chainType.NewCoin(constants.ChainMainNameStr+"/"+"btc", sdk.NewInt(21000000)),
-	)
+	Convey("test query supply", t, func() {
 
-	supplyAcc := keeper.GetModuleAccount(ctx, types.ModuleName).GetID()
-	fInitCoins(t, ctx, *app.AssetKeeper(), supplyCoins, supplyAcc)
+		supplyCoins := chainType.NewCoins(
+			chainType.NewCoin(constants.DefaultBondDenom, sdk.NewInt(100)),
+			chainType.NewCoin(constants.ChainMainNameStr+"/"+"photon", sdk.NewInt(50)),
+			chainType.NewCoin(constants.ChainMainNameStr+"/"+"atom", sdk.NewInt(2000)),
+			chainType.NewCoin(constants.ChainMainNameStr+"/"+"btc", sdk.NewInt(21000000)),
+		)
 
-	query := abci.RequestQuery{
-		Path: "",
-		Data: []byte{},
-	}
+		supplyAcc := keeper.GetModuleAccount(ctx, types.ModuleName).GetID()
+		fInitCoins(t, ctx, *app.AssetKeeper(), supplyCoins, supplyAcc)
 
-	querier := keep.NewQuerier(keeper)
+		query := abci.RequestQuery{
+			Path: "",
+			Data: []byte{},
+		}
 
-	//keeper.SetSupply(ctx, types.NewSupply(supplyCoins))
+		querier := keep.NewQuerier(keeper)
 
-	queryTotalSupplyParams := types.NewQueryTotalSupplyParams(1, 10)
-	bz, errRes := cdc.MarshalJSON(queryTotalSupplyParams)
-	require.Nil(t, errRes)
+		//keeper.SetSupply(ctx, types.NewSupply(supplyCoins))
 
-	query.Path = fmt.Sprintf("/custom/supply/%s", types.QueryTotalSupply)
-	query.Data = bz
+		queryTotalSupplyParams := types.NewQueryTotalSupplyParams(1, 10)
+		bz, errRes := cdc.MarshalJSON(queryTotalSupplyParams)
+		require.Nil(t, errRes)
 
-	res, err := querier(ctx, []string{types.QueryTotalSupply}, query)
-	require.Nil(t, err)
+		query.Path = fmt.Sprintf("/custom/supply/%s", types.QueryTotalSupply)
+		query.Data = bz
 
-	var totalCoins chainType.Coins
-	errRes = cdc.UnmarshalJSON(res, &totalCoins)
-	require.Nil(t, errRes)
-	require.Equal(t, supplyCoins, totalCoins)
+		res, err := querier(ctx, []string{types.QueryTotalSupply}, query)
+		require.Nil(t, err)
 
-	querySupplyParams := types.NewQuerySupplyOfParams(constants.DefaultBondDenom)
-	bz, errRes = cdc.MarshalJSON(querySupplyParams)
-	require.Nil(t, errRes)
+		var totalCoins chainType.Coins
+		errRes = cdc.UnmarshalJSON(res, &totalCoins)
+		require.Nil(t, errRes)
+		require.Equal(t, supplyCoins, totalCoins)
 
-	query.Path = fmt.Sprintf("/custom/supply/%s", types.QuerySupplyOf)
-	query.Data = bz
+		querySupplyParams := types.NewQuerySupplyOfParams(constants.DefaultBondDenom)
+		bz, errRes = cdc.MarshalJSON(querySupplyParams)
+		require.Nil(t, errRes)
 
-	res, err = querier(ctx, []string{types.QuerySupplyOf}, query)
-	require.Nil(t, err)
+		query.Path = fmt.Sprintf("/custom/supply/%s", types.QuerySupplyOf)
+		query.Data = bz
 
-	var supply sdk.Int
-	errRes = supply.UnmarshalJSON(res)
-	require.Nil(t, errRes)
-	require.True(sdk.IntEq(t, sdk.NewInt(100), supply))
+		res, err = querier(ctx, []string{types.QuerySupplyOf}, query)
+		require.Nil(t, err)
+
+		var supply sdk.Int
+		errRes = supply.UnmarshalJSON(res)
+		require.Nil(t, errRes)
+		require.True(sdk.IntEq(t, sdk.NewInt(100), supply))
+
+	})
 }


### PR DESCRIPTION
## Summary

Add Init supply check in create asset, to ensure init supply should large than max supply.

## Modifys

- add check for init supply
- fix testcase faileds

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes