### PR TITLE
Add Lock Coins Forever (Freezed Coins) Support

### DIFF
--- a/x/asset/keeper/keeper_locked.go
+++ b/x/asset/keeper/keeper_locked.go
@@ -99,7 +99,7 @@ func (a AssetKeeper) LockCoins(ctx sdk.Context, account types.AccountID, unlockB
 		return types.ErrAssetLockCoinsNoEnough
 	}
 
-	if unlockBlockHeight <= ctx.BlockHeight() {
+	if unlockBlockHeight > 0 && unlockBlockHeight <= ctx.BlockHeight() {
 		return types.ErrAssetLockUnlockBlockHeightErr
 	}
 
@@ -108,10 +108,21 @@ func (a AssetKeeper) LockCoins(ctx sdk.Context, account types.AccountID, unlockB
 		return sdkerrors.Wrap(err, "LockCoins: get coins locked stat")
 	}
 
-	stat.Lockeds = append(stat.Lockeds, LockedCoins{
-		Coins:             coins,
-		UnlockBlockHeight: unlockBlockHeight,
-	})
+	inserted := false
+	for idx, locked := range stat.Lockeds {
+		if locked.UnlockBlockHeight == unlockBlockHeight {
+			stat.Lockeds[idx].Coins = locked.Coins.Add(coins...)
+			inserted = true
+			break
+		}
+	}
+
+	if !inserted {
+		stat.Lockeds = append(stat.Lockeds, LockedCoins{
+			Coins:             coins,
+			UnlockBlockHeight: unlockBlockHeight,
+		})
+	}
 
 	if err := a.setCoinsLockedStat(ctx, account, stat); err != nil {
 		return sdkerrors.Wrap(err, "LockCoins: set coins locked stat")
@@ -144,7 +155,7 @@ func (a AssetKeeper) UnLockCoins(ctx sdk.Context, account types.AccountID, coins
 	}
 
 	for _, l := range stat.Lockeds {
-		if l.UnlockBlockHeight <= height {
+		if l.UnlockBlockHeight >= 0 && l.UnlockBlockHeight <= height {
 			coinsCanUnLocked = coinsCanUnLocked.Add(l.Coins...)
 		} else {
 			newStat.Lockeds = append(newStat.Lockeds, l)
@@ -169,6 +180,62 @@ func (a AssetKeeper) UnLockCoins(ctx sdk.Context, account types.AccountID, coins
 	err = a.setCoinsLockedStat(ctx, account, newStat)
 	return sdkerrors.Wrap(err, "UnlockedCoins")
 
+}
+
+// UnLockFreezedCoins unlock freezed coins which UnlockBlockHeight is < 0
+func (a AssetKeeper) UnLockFreezedCoins(ctx sdk.Context, account types.AccountID, coins types.Coins) error {
+	coinLocked, err := a.getCoinsLocked(ctx, account)
+	if err != nil {
+		return sdkerrors.Wrap(err, "UnlockCoins: get coins locked")
+	}
+
+	stat, err := a.getCoinsLockedStat(ctx, account)
+	if err != nil {
+		return sdkerrors.Wrap(err, "UnlockCoins: get coins locked stat")
+	}
+
+	founded := false
+	for idx, l := range stat.Lockeds {
+		if l.UnlockBlockHeight < 0 {
+			coinsLocked := stat.Lockeds[idx].Coins
+
+			newCoins, hasNeg := coinsLocked.SafeSub(coins)
+			if hasNeg {
+				return sdkerrors.Wrapf(types.ErrAssetUnLockCoins, "unlock sum be %s >= %s",
+					coinsLocked.String(), coins.String())
+			}
+
+			stat.Lockeds[idx].Coins = newCoins
+			if newCoins.IsZero() {
+				ll := len(stat.Lockeds)
+				if (idx + 1) != ll {
+					stat.Lockeds[idx] = stat.Lockeds[ll-1]
+				}
+				stat.Lockeds = stat.Lockeds[:ll-1]
+			}
+			founded = true
+			break
+		}
+	}
+
+	if !founded {
+		return sdkerrors.Wrapf(types.ErrAssetUnLockCoins,
+			"no found locked freezed coins")
+	}
+
+	newCoinsLocked, isNegative := coinLocked.SafeSub(coins)
+	if isNegative {
+		return sdkerrors.Wrapf(types.ErrAssetUnLockCoins, "unlock sum be %s >= %s",
+			coins.String(), coinLocked.String())
+	}
+
+	err = a.setCoinsLocked(ctx, account, newCoinsLocked)
+	if err != nil {
+		return sdkerrors.Wrap(err, "UnlockedCoins")
+	}
+
+	err = a.setCoinsLockedStat(ctx, account, stat)
+	return sdkerrors.Wrap(err, "UnlockedCoins")
 }
 
 // GetLockCoins get locked data

--- a/x/asset/keeper/keeper_locked_test.go
+++ b/x/asset/keeper/keeper_locked_test.go
@@ -1,0 +1,218 @@
+package keeper_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KuChainNetwork/kuchain/chain/types"
+	"github.com/KuChainNetwork/kuchain/test/simapp"
+	assetTypes "github.com/KuChainNetwork/kuchain/x/asset/types"
+	. "github.com/smartystreets/goconvey/convey"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+func TestLockedForever(t *testing.T) {
+	app, _ := createTestApp()
+
+	Convey("test locked forever", t, func() {
+		ctx := app.NewTestContext()
+
+		err := app.AssetKeeper().LockCoins(ctx, account1, -1, types.NewInt64CoreCoins(1000))
+		So(err, ShouldBeNil)
+
+		all, locks, err := app.AssetKeeper().GetLockCoins(ctx, account1)
+		So(all, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+		So(len(locks), ShouldEqual, 1)
+		So(locks[0].UnlockBlockHeight < 0, ShouldBeTrue)
+
+		err = app.AssetKeeper().LockCoins(ctx, account1, 100, types.NewInt64CoreCoins(2000))
+		So(err, ShouldBeNil)
+
+		all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account1)
+		So(all, simapp.ShouldEq, types.NewInt64CoreCoins(3000))
+		So(len(locks), ShouldEqual, 2)
+		So(locks[0].UnlockBlockHeight < 0, ShouldBeTrue)
+
+		ctx = app.BaseApp.NewContext(true,
+			abci.Header{
+				Height: 101,
+				Time:   time.Now(),
+			})
+
+		err = app.AssetKeeper().UnLockCoins(ctx, account1, types.NewInt64CoreCoins(2000))
+		So(err, ShouldBeNil)
+
+		err = app.AssetKeeper().UnLockCoins(ctx, account1, types.NewInt64CoreCoins(1000))
+		So(err, simapp.ShouldErrIs, assetTypes.ErrAssetUnLockCoins)
+
+		all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account1)
+		So(all, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+		So(len(locks), ShouldEqual, 1)
+		So(locks[0].UnlockBlockHeight < 0, ShouldBeTrue)
+
+		ctx = app.BaseApp.NewContext(true,
+			abci.Header{
+				Height: 9223372036854775800,
+				Time:   time.Now(),
+			})
+
+		err = app.AssetKeeper().UnLockCoins(ctx, account1, types.NewInt64CoreCoins(1000))
+		So(err, simapp.ShouldErrIs, assetTypes.ErrAssetUnLockCoins)
+
+		all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account1)
+		So(all, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+		So(len(locks), ShouldEqual, 1)
+		So(locks[0].UnlockBlockHeight < 0, ShouldBeTrue)
+	})
+}
+
+func TestLockedForeverUnlock(t *testing.T) {
+	app, _ := createTestAppWithCoins()
+
+	Convey("test unlocked forever", t, func() {
+		ctx := app.NewTestContext()
+
+		Convey("test first one locked forever", func() {
+			So(app.AssetKeeper().LockCoins(ctx, account1, -1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+			So(app.AssetKeeper().LockCoins(ctx, account1, -1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+
+			all, locks, err := app.AssetKeeper().GetLockCoins(ctx, account1)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(len(locks), ShouldEqual, 1)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, -1)
+
+			So(app.AssetKeeper().UnLockFreezedCoins(ctx, account1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+
+			all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account1)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+			So(len(locks), ShouldEqual, 1)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, -1)
+
+			So(app.AssetKeeper().UnLockFreezedCoins(ctx, account1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+			all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account1)
+			So(err, ShouldBeNil)
+			So(all.IsZero(), ShouldBeTrue)
+			So(len(locks), ShouldEqual, 0)
+		})
+
+		Convey("test last one locked forever", func() {
+			So(app.AssetKeeper().LockCoins(ctx, account2, 10, types.NewInt64CoreCoins(2000)), ShouldBeNil)
+			So(app.AssetKeeper().LockCoins(ctx, account2, -1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+			So(app.AssetKeeper().LockCoins(ctx, account2, -1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+
+			all, locks, err := app.AssetKeeper().GetLockCoins(ctx, account2)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(4000))
+			So(len(locks), ShouldEqual, 2)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, 10)
+			So(locks[1].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[1].UnlockBlockHeight, ShouldEqual, -1)
+
+			So(app.AssetKeeper().UnLockFreezedCoins(ctx, account2, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+
+			all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account2)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(3000))
+			So(len(locks), ShouldEqual, 2)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, 10)
+			So(locks[1].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+			So(locks[1].UnlockBlockHeight, ShouldEqual, -1)
+
+			So(app.AssetKeeper().UnLockFreezedCoins(ctx, account2, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+
+			all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account2)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(len(locks), ShouldEqual, 1)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, 10)
+		})
+
+		Convey("test mid one locked forever", func() {
+			So(app.AssetKeeper().LockCoins(ctx, account3, 10, types.NewInt64CoreCoins(2000)), ShouldBeNil)
+			So(app.AssetKeeper().LockCoins(ctx, account3, -1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+			So(app.AssetKeeper().LockCoins(ctx, account3, -1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+			So(app.AssetKeeper().LockCoins(ctx, account3, 11, types.NewInt64CoreCoins(2000)), ShouldBeNil)
+
+			all, locks, err := app.AssetKeeper().GetLockCoins(ctx, account3)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(6000))
+			So(len(locks), ShouldEqual, 3)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, 10)
+			So(locks[1].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[1].UnlockBlockHeight, ShouldEqual, -1)
+			So(locks[2].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[2].UnlockBlockHeight, ShouldEqual, 11)
+
+			So(app.AssetKeeper().UnLockFreezedCoins(ctx, account3, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+
+			all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account3)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(5000))
+			So(len(locks), ShouldEqual, 3)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, 10)
+			So(locks[1].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+			So(locks[1].UnlockBlockHeight, ShouldEqual, -1)
+			So(locks[2].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[2].UnlockBlockHeight, ShouldEqual, 11)
+
+			So(app.AssetKeeper().UnLockFreezedCoins(ctx, account3, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+
+			all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account3)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(4000))
+			So(len(locks), ShouldEqual, 2)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, 10)
+			So(locks[1].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[1].UnlockBlockHeight, ShouldEqual, 11)
+		})
+	})
+}
+
+func TestLockedForeverUnlockErr(t *testing.T) {
+	app, _ := createTestAppWithCoins()
+
+	Convey("test unlocked forever", t, func() {
+		ctx := app.NewTestContext()
+
+		Convey("test one locked forever no enough", func() {
+			So(app.AssetKeeper().LockCoins(ctx, account1, -1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+			So(app.AssetKeeper().LockCoins(ctx, account1, -1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+
+			all, locks, err := app.AssetKeeper().GetLockCoins(ctx, account1)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(len(locks), ShouldEqual, 1)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(2000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, -1)
+
+			So(app.AssetKeeper().UnLockFreezedCoins(ctx, account1, types.NewInt64CoreCoins(1000)), ShouldBeNil)
+
+			all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account1)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+			So(len(locks), ShouldEqual, 1)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, -1)
+
+			So(app.AssetKeeper().UnLockFreezedCoins(ctx, account1, types.NewInt64CoreCoins(1001)),
+				simapp.ShouldErrIs, assetTypes.ErrAssetUnLockCoins)
+
+			all, locks, err = app.AssetKeeper().GetLockCoins(ctx, account1)
+			So(err, ShouldBeNil)
+			So(all, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+			So(len(locks), ShouldEqual, 1)
+			So(locks[0].Coins, simapp.ShouldEq, types.NewInt64CoreCoins(1000))
+			So(locks[0].UnlockBlockHeight, ShouldEqual, -1)
+		})
+	})
+}

--- a/x/asset/keeper/keeper_test.go
+++ b/x/asset/keeper/keeper_test.go
@@ -43,6 +43,24 @@ func createTestApp() (*simapp.SimApp, sdk.Context) {
 	return app, ctxCheck
 }
 
+func createTestAppWithCoins() (*simapp.SimApp, sdk.Context) {
+	asset1 := types.NewInt64Coins(constants.DefaultBondDenom, 10000000000)
+
+	genAccs := simapp.NewGenesisAccounts(wallet.GetRootAuth(),
+		simapp.NewSimGenesisAccount(account1, addr1).WithAsset(asset1),
+		simapp.NewSimGenesisAccount(account2, addr2).WithAsset(asset1),
+		simapp.NewSimGenesisAccount(account3, addr3).WithAsset(asset1),
+	)
+	app := simapp.SetupWithGenesisAccounts(genAccs)
+
+	ctxCheck := app.BaseApp.NewContext(true,
+		abci.Header{
+			Time:   time.Now(),
+			Height: app.LastBlockHeight() + 1,
+		})
+	return app, ctxCheck
+}
+
 func TestAssetTransfer(t *testing.T) {
 	app, ctx := createTestApp()
 

--- a/x/asset/types/msgs.go
+++ b/x/asset/types/msgs.go
@@ -346,6 +346,7 @@ func (msg MsgLockCoin) ValidateBasic() error {
 		}
 	}
 
+	// now version user cannot lock its coin forever
 	if data.UnlockBlockHeight <= 0 {
 		return ErrAssetLockUnlockBlockHeightErr
 	}


### PR DESCRIPTION
## Summary

In Kuchain, if unlockHeightNum is < 0, which will be -1, it means the coins are locked forever util some other functions to unlock it, we add some support api for it.

## Modifys

- add a api in asset keeper for unlock forever coins
- merge locks data which unlock height is same

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes