### PR TITLE
Add SigIn and SigOut For Dex

### DIFF
--- a/chain/types/alias.go
+++ b/chain/types/alias.go
@@ -1,6 +1,8 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 type (
 	AccAddress = sdk.AccAddress
@@ -9,6 +11,12 @@ type (
 
 var (
 	AccAddressFromBech32 = sdk.AccAddressFromBech32
+)
+
+type (
+	StoreKey          = sdk.StoreKey
+	KVStoreKey        = sdk.KVStoreKey
+	TransientStoreKey = sdk.TransientStoreKey
 )
 
 // MustAccAddressFromBech32 AccAddressFromBech32 if error then panic

--- a/test/simapp/app.go
+++ b/test/simapp/app.go
@@ -105,6 +105,8 @@ type SimApp struct {
 	*bam.BaseApp
 	cdc *codec.Codec
 
+	wallet *Wallet
+
 	invCheckPeriod uint
 
 	// keys to access the substores
@@ -434,4 +436,13 @@ func GetMaccPerms() map[string][]string {
 		dupMaccPerms[k] = v
 	}
 	return dupMaccPerms
+}
+
+func (app *SimApp) WithWallet(w *Wallet) *SimApp {
+	app.wallet = w
+	return app
+}
+
+func (app SimApp) GetWallet() *Wallet {
+	return app.wallet
 }

--- a/test/simapp/app_creator.go
+++ b/test/simapp/app_creator.go
@@ -1,0 +1,8 @@
+package simapp
+
+// CreateAppForTest create app for test
+func CreateAppForTest(w *Wallet) *SimApp {
+	genAccs := NewGenesisAccounts(w.GetRootAuth())
+
+	return SetupWithGenesisAccounts(genAccs)
+}

--- a/x/asset/handler.go
+++ b/x/asset/handler.go
@@ -319,6 +319,17 @@ func handleMsgApprove(ctx chainTypes.Context, k keeper.AssetCoinsKeeper, msg *ty
 
 	ctx.RequireAuth(msgData.Id)
 
+	apporveCoins, err := k.GetApproveCoins(ctx.Context(), msgData.Id, msgData.Spender)
+	if apporveCoins != nil {
+		if apporveCoins.IsLock == true {
+			return nil, types.ErrAssetApporveCannotChangeLock
+		}
+
+		if apporveCoins.IsLock && apporveCoins.Amount.IsAnyGT(msgData.Amount) {
+			return nil, sdkerrors.Wrap(types.ErrAssetApporveCannotChangeLock, "amount in lock apporve cannot be less")
+		}
+	}
+
 	err = k.Approve(ctx.Context(), msgData.Id, msgData.Spender, msgData.Amount, false)
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "msg approve handler error")

--- a/x/asset/keeper/keeper_bank.go
+++ b/x/asset/keeper/keeper_bank.go
@@ -40,10 +40,6 @@ func (a AssetKeeper) Approve(ctx sdk.Context, id, spender types.AccountID, amt t
 		if apporveCoins.IsLock != isLock {
 			return types.ErrAssetApporveCannotChangeLock
 		}
-
-		if apporveCoins.IsLock && apporveCoins.Amount.IsAnyGT(amt) {
-			return sdkerrors.Wrap(types.ErrAssetApporveCannotChangeLock, "amount in lock apporve cannot be less")
-		}
 	} else {
 		apporveCoins = NewApproveData(amt)
 	}

--- a/x/asset/keeper/keeper_internal.go
+++ b/x/asset/keeper/keeper_internal.go
@@ -219,12 +219,21 @@ func (a AssetKeeper) getCoinsPower(ctx sdk.Context, account types.AccountID) (ty
 
 func (a AssetKeeper) setApprove(ctx sdk.Context, account, spender types.AccountID, data ApproveData) error {
 	store := ctx.KVStore(a.key)
+	key := types.ApproveStoreKey(account, spender)
+
+	if data.Amount.IsZero() {
+		// delete
+		if store.Has(key) {
+			store.Delete(key)
+		}
+		return nil
+	}
+
 	bz, err := a.cdc.MarshalBinaryBare(data)
 	if err != nil {
 		return sdkerrors.Wrap(err, "set coins marshal error")
 	}
 
-	key := types.ApproveStoreKey(account, spender)
 	if bz == nil {
 		if store.Has(key) {
 			store.Delete(key)

--- a/x/dex/alias.go
+++ b/x/dex/alias.go
@@ -23,6 +23,8 @@ var (
 
 type (
 	GenesisState = types.GenesisState
+	AccountID    = types.AccountID
+	Coins        = types.Coins
 )
 
 type (

--- a/x/dex/dex_test.go
+++ b/x/dex/dex_test.go
@@ -31,6 +31,16 @@ var (
 	addAccount1 = types.NewAccountIDFromAccAdd(addr1)
 )
 
+var (
+	dexName1    = types.MustName("dexaccount1")
+	dexAccount1 = types.NewAccountIDFromName(dexName1)
+	dexAddr1    = wallet.NewAccAddressByName(dexName1)
+
+	dexName2    = types.MustName("dexaccount2")
+	dexAccount2 = types.NewAccountIDFromName(dexName2)
+	dexAddr2    = wallet.NewAccAddressByName(dexName2)
+)
+
 func createAppForTest() (*simapp.SimApp, sdk.Context) {
 	asset1 := types.NewCoins(
 		types.NewInt64Coin("foo/coin", 10000000),
@@ -47,8 +57,11 @@ func createAppForTest() (*simapp.SimApp, sdk.Context) {
 		simapp.NewSimGenesisAccount(account3, addr3).WithAsset(asset3),
 		simapp.NewSimGenesisAccount(account4, addr4).WithAsset(asset2),
 		simapp.NewSimGenesisAccount(account5, addr5).WithAsset(asset2),
+		simapp.NewSimGenesisAccount(dexAccount1, dexAddr1).WithAsset(asset2),
+		simapp.NewSimGenesisAccount(dexAccount2, dexAddr2).WithAsset(asset2),
 	)
 	app := simapp.SetupWithGenesisAccounts(genAccs)
+	app = app.WithWallet(wallet)
 
 	ctxCheck := app.BaseApp.NewContext(true, abci.Header{Height: app.LastBlockHeight() + 1})
 	return app, ctxCheck

--- a/x/dex/handler.go
+++ b/x/dex/handler.go
@@ -1,6 +1,8 @@
 package dex
 
 import (
+	"strconv"
+
 	"github.com/pkg/errors"
 
 	"github.com/KuChainNetwork/kuchain/chain/msg"
@@ -22,6 +24,8 @@ func NewHandler(k Keeper) msg.Handler {
 			return handleMsgDestroyDex(ctx, k, theMsg)
 		case *types.MsgDexSigIn:
 			return handleMsgDexSigIn(ctx, k, theMsg)
+		case *types.MsgDexSigOut:
+			return handleMsgDexSigOut(ctx, k, theMsg)
 		default:
 			return nil, errors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized asset message type: %T", msg)
 		}
@@ -150,6 +154,44 @@ func handleMsgDexSigIn(ctx chainTypes.Context, k Keeper, msg *types.MsgDexSigIn)
 			sdk.NewAttribute(types.AttributeKeyUser, msgData.User.String()),
 			sdk.NewAttribute(types.AttributeKeyDex, msgData.Dex.String()),
 			sdk.NewAttribute(types.AttributeKeyAmount, msgData.Amount.String()),
+		),
+	)
+
+	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
+}
+
+func handleMsgDexSigOut(ctx chainTypes.Context, k Keeper, msg *types.MsgDexSigOut) (*sdk.Result, error) {
+	logger := ctx.Logger()
+
+	msgData, err := msg.GetData()
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debug("handle dex sigout",
+		"user", msgData.User, "dex", msgData.Dex, "amount", msgData.Amount, "isTimeout", msgData.IsTimeout)
+
+	// Note: two mode, if just has user's auth, need to wait
+	// TODO: wait mode
+
+	if msgData.IsTimeout {
+		ctx.RequireAuth(msgData.User)
+	} else {
+		ctx.RequireAuth(msgData.Dex)
+	}
+
+	if err := k.SigOut(ctx.Context(), msgData.IsTimeout, msgData.User, msgData.Dex, msgData.Amount); err != nil {
+		return nil, err
+	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeDexSigOut,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(types.AttributeKeyUser, msgData.User.String()),
+			sdk.NewAttribute(types.AttributeKeyDex, msgData.Dex.String()),
+			sdk.NewAttribute(types.AttributeKeyAmount, msgData.Amount.String()),
+			sdk.NewAttribute(types.AttributeKeyIsTimeout, strconv.FormatBool(msgData.IsTimeout)),
 		),
 	)
 

--- a/x/dex/handler.go
+++ b/x/dex/handler.go
@@ -139,7 +139,9 @@ func handleMsgDexSigIn(ctx chainTypes.Context, k Keeper, msg *types.MsgDexSigIn)
 
 	ctx.RequireAuth(msgData.User)
 
-	// FIXME: imp sigin
+	if err := k.SigIn(ctx.Context(), msgData.User, msgData.Dex, msgData.Amount); err != nil {
+		return nil, err
+	}
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(

--- a/x/dex/handler.go
+++ b/x/dex/handler.go
@@ -20,6 +20,8 @@ func NewHandler(k Keeper) msg.Handler {
 			return handleMsgUpdateDexDescription(ctx, k, theMsg)
 		case *types.MsgDestroyDex:
 			return handleMsgDestroyDex(ctx, k, theMsg)
+		case *types.MsgDexSigIn:
+			return handleMsgDexSigIn(ctx, k, theMsg)
 		default:
 			return nil, errors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized asset message type: %T", msg)
 		}
@@ -122,4 +124,32 @@ func handleMsgDestroyDex(ctx chainTypes.Context,
 	)
 	res = &sdk.Result{Events: ctx.EventManager().Events()}
 	return
+}
+
+func handleMsgDexSigIn(ctx chainTypes.Context, k Keeper, msg *types.MsgDexSigIn) (*sdk.Result, error) {
+	logger := ctx.Logger()
+
+	msgData, err := msg.GetData()
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debug("handle dex sigin",
+		"user", msgData.User, "dex", msgData.Dex, "amount", msgData.Amount)
+
+	ctx.RequireAuth(msgData.User)
+
+	// FIXME: imp sigin
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeDexSigIn,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(types.AttributeKeyUser, msgData.User.String()),
+			sdk.NewAttribute(types.AttributeKeyDex, msgData.Dex.String()),
+			sdk.NewAttribute(types.AttributeKeyAmount, msgData.Amount.String()),
+		),
+	)
+
+	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
 }

--- a/x/dex/handler_signin_test.go
+++ b/x/dex/handler_signin_test.go
@@ -1,0 +1,45 @@
+package dex_test
+
+import (
+	"testing"
+
+	"github.com/KuChainNetwork/kuchain/chain/types"
+	"github.com/KuChainNetwork/kuchain/test/simapp"
+	dexTypes "github.com/KuChainNetwork/kuchain/x/dex/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func SignInMsgForTest(t *testing.T, app *simapp.SimApp, isSuccess bool, id, dex types.AccountID, amount types.Coins) error {
+	wallet := app.GetWallet()
+
+	ctx := app.NewTestContext()
+
+	msg := dexTypes.NewMsgDexSigIn(
+		wallet.GetAuth(id),
+		id,
+		dex,
+		amount)
+
+	tx := simapp.NewTxForTest(
+		id,
+		[]sdk.Msg{
+			&msg,
+		}, wallet.PrivKey(wallet.GetAuth(id)))
+
+	if !isSuccess {
+		tx = tx.WithCannotPass()
+	}
+
+	return simapp.CheckTxs(t, app, ctx, tx)
+}
+
+func TestSignInMsg(t *testing.T) {
+	app, _ := createAppForTest()
+
+	Convey("test signIn msg", t, func() {
+		amt := types.NewInt64CoreCoins(1000000)
+
+		So(SignInMsgForTest(t, app, true, account1, dexAccount1, amt), ShouldBeNil)
+	})
+}

--- a/x/dex/handler_signin_test.go
+++ b/x/dex/handler_signin_test.go
@@ -34,6 +34,31 @@ func SignInMsgForTest(t *testing.T, app *simapp.SimApp, isSuccess bool, id, dex 
 	return simapp.CheckTxs(t, app, ctx, tx)
 }
 
+func SignOutMsgByDexForTest(t *testing.T, app *simapp.SimApp, isSuccess bool, id, dex types.AccountID, amount types.Coins) error {
+	wallet := app.GetWallet()
+
+	ctx := app.NewTestContext()
+
+	msg := dexTypes.NewMsgDexSigOut(
+		wallet.GetAuth(dex),
+		false,
+		id,
+		dex,
+		amount)
+
+	tx := simapp.NewTxForTest(
+		dex,
+		[]sdk.Msg{
+			&msg,
+		}, wallet.PrivKey(wallet.GetAuth(dex)))
+
+	if !isSuccess {
+		tx = tx.WithCannotPass()
+	}
+
+	return simapp.CheckTxs(t, app, ctx, tx)
+}
+
 func TestSignInMsg(t *testing.T) {
 	app, _ := createAppForTest()
 
@@ -58,5 +83,64 @@ func TestSignInMsg(t *testing.T) {
 		So(len(locks), ShouldEqual, 1)
 		So(locks[0].Coins, simapp.ShouldEq, amt)
 		So(locks[0].UnlockBlockHeight, ShouldBeLessThan, 0)
+	})
+}
+
+func TestSignOutMsg(t *testing.T) {
+	app, _ := createAppForTest()
+
+	Convey("test signOut msg", t, func() {
+		So(CreateDexForTest(t, app, true, dexAccount1, types.NewInt64CoreCoins(1000000000), []byte("dex for test")), ShouldBeNil)
+
+		amt := types.NewInt64CoreCoins(1000000)
+		So(SignInMsgForTest(t, app, true, account1, dexAccount1, amt), ShouldBeNil)
+
+		ctx := app.NewTestContext()
+		assetKeeper := app.AssetKeeper()
+
+		data, err := assetKeeper.GetApproveCoins(ctx, account1, dexAccount1)
+		So(err, ShouldBeNil)
+		So(data, ShouldNotBeNil)
+		So(data.IsLock, ShouldBeTrue)
+		So(data.Amount, simapp.ShouldEq, amt)
+
+		all, locks, err := assetKeeper.GetLockCoins(ctx, account1)
+		So(err, ShouldBeNil)
+		So(all, simapp.ShouldEq, amt)
+		So(len(locks), ShouldEqual, 1)
+		So(locks[0].Coins, simapp.ShouldEq, amt)
+		So(locks[0].UnlockBlockHeight, ShouldBeLessThan, 0)
+
+		out := types.NewInt64CoreCoins(77777)
+		left := amt.Sub(out)
+		So(SignOutMsgByDexForTest(t, app, true, account1, dexAccount1, out), ShouldBeNil)
+
+		ctx = app.NewTestContext()
+
+		data, err = assetKeeper.GetApproveCoins(ctx, account1, dexAccount1)
+		So(err, ShouldBeNil)
+		So(data, ShouldNotBeNil)
+		So(data.IsLock, ShouldBeTrue)
+		So(data.Amount, simapp.ShouldEq, left)
+
+		all, locks, err = assetKeeper.GetLockCoins(ctx, account1)
+		So(err, ShouldBeNil)
+		So(all, simapp.ShouldEq, left)
+		So(len(locks), ShouldEqual, 1)
+		So(locks[0].Coins, simapp.ShouldEq, left)
+		So(locks[0].UnlockBlockHeight, ShouldBeLessThan, 0)
+
+		So(SignOutMsgByDexForTest(t, app, true, account1, dexAccount1, left), ShouldBeNil)
+
+		ctx = app.NewTestContext()
+
+		data, err = assetKeeper.GetApproveCoins(ctx, account1, dexAccount1)
+		So(err, ShouldBeNil)
+		So(data, ShouldBeNil)
+
+		all, locks, err = assetKeeper.GetLockCoins(ctx, account1)
+		So(err, ShouldBeNil)
+		So(all.IsZero(), ShouldBeTrue)
+		So(len(locks), ShouldEqual, 0)
 	})
 }

--- a/x/dex/handler_signin_test.go
+++ b/x/dex/handler_signin_test.go
@@ -38,8 +38,25 @@ func TestSignInMsg(t *testing.T) {
 	app, _ := createAppForTest()
 
 	Convey("test signIn msg", t, func() {
-		amt := types.NewInt64CoreCoins(1000000)
+		So(CreateDexForTest(t, app, true, dexAccount1, types.NewInt64CoreCoins(1000000000), []byte("dex for test")), ShouldBeNil)
 
+		amt := types.NewInt64CoreCoins(1000000)
 		So(SignInMsgForTest(t, app, true, account1, dexAccount1, amt), ShouldBeNil)
+
+		ctx := app.NewTestContext()
+		assetKeeper := app.AssetKeeper()
+
+		data, err := assetKeeper.GetApproveCoins(ctx, account1, dexAccount1)
+		So(err, ShouldBeNil)
+		So(data, ShouldNotBeNil)
+		So(data.IsLock, ShouldBeTrue)
+		So(data.Amount, simapp.ShouldEq, amt)
+
+		all, locks, err := assetKeeper.GetLockCoins(ctx, account1)
+		So(err, ShouldBeNil)
+		So(all, simapp.ShouldEq, amt)
+		So(len(locks), ShouldEqual, 1)
+		So(locks[0].Coins, simapp.ShouldEq, amt)
+		So(locks[0].UnlockBlockHeight, ShouldBeLessThan, 0)
 	})
 }

--- a/x/dex/handler_test.go
+++ b/x/dex/handler_test.go
@@ -11,8 +11,9 @@ import (
 	"github.com/tendermint/tendermint/libs/rand"
 )
 
-func CreateDexForTest(t *testing.T, app *simapp.SimApp, wallet *simapp.Wallet, isSuccess bool, account types.AccountID, stakings types.Coins, desc []byte) error {
+func CreateDexForTest(t *testing.T, app *simapp.SimApp, isSuccess bool, account types.AccountID, stakings types.Coins, desc []byte) error {
 	ctx := app.NewTestContext()
+	wallet := app.GetWallet()
 
 	var (
 		acc     = account
@@ -161,14 +162,14 @@ func TestHandleCreateDex(t *testing.T) {
 	})
 
 	Convey("test transfer desc too long", t, func() {
-		So(CreateDexForTest(t, app, wallet,
+		So(CreateDexForTest(t, app,
 			false,
 			account4, types.NewInt64CoreCoins(111),
 			make([]byte, 520)), simapp.ShouldErrIs, dexTypes.ErrDexDescTooLong)
 	})
 
 	Convey("test transfer create two times", t, func() {
-		So(CreateDexForTest(t, app, wallet,
+		So(CreateDexForTest(t, app,
 			false,
 			account5, types.NewInt64CoreCoins(111),
 			[]byte("hello")), simapp.ShouldErrIs, dexTypes.ErrDexHadCreated)
@@ -179,12 +180,12 @@ func TestHandleCreateDexNumber(t *testing.T) {
 	app, _ := createAppForTest()
 
 	Convey("test create dex number", t, func() {
-		So(CreateDexForTest(t, app, wallet,
+		So(CreateDexForTest(t, app,
 			true,
 			account4, types.NewInt64CoreCoins(111),
 			[]byte("account4")), ShouldBeNil)
 
-		So(CreateDexForTest(t, app, wallet,
+		So(CreateDexForTest(t, app,
 			true,
 			account5, types.NewInt64CoreCoins(111),
 			[]byte("account5")), ShouldBeNil)
@@ -218,7 +219,7 @@ func TestHandleUpdateDexDescription(t *testing.T) {
 			auth    = wallet.GetAuth(acc)
 		)
 
-		So(CreateDexForTest(t, app, wallet,
+		So(CreateDexForTest(t, app,
 			true,
 			acc, types.NewInt64CoreCoins(111),
 			[]byte("account4")), ShouldBeNil)
@@ -271,7 +272,7 @@ func TestHandleDestroyDex(t *testing.T) {
 			auth    = wallet.GetAuth(acc)
 		)
 
-		So(CreateDexForTest(t, app, wallet,
+		So(CreateDexForTest(t, app,
 			true,
 			acc, types.NewInt64CoreCoins(1000),
 			[]byte("account4")), ShouldBeNil)

--- a/x/dex/keeper/interfaces.go
+++ b/x/dex/keeper/interfaces.go
@@ -1,0 +1,16 @@
+package keeper
+
+import (
+	"github.com/KuChainNetwork/kuchain/chain/types"
+	"github.com/KuChainNetwork/kuchain/x/asset/keeper"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type IAssetKeeper interface {
+	LockCoins(ctx sdk.Context, account types.AccountID, unlockBlockHeight int64, coins types.Coins) error
+	Approve(ctx sdk.Context, id, spender types.AccountID, amt types.Coins, isLock bool) error
+	CoinsToPower(ctx sdk.Context, from, to types.AccountID, amt types.Coins) error
+
+	GetLockCoins(ctx sdk.Context, account types.AccountID) (types.Coins, []keeper.LockedCoins, error)
+	GetApproveCoins(ctx sdk.Context, account, spender types.AccountID) (*keeper.ApproveData, error)
+}

--- a/x/dex/keeper/interfaces.go
+++ b/x/dex/keeper/interfaces.go
@@ -10,6 +10,7 @@ type IAssetKeeper interface {
 	LockCoins(ctx sdk.Context, account types.AccountID, unlockBlockHeight int64, coins types.Coins) error
 	Approve(ctx sdk.Context, id, spender types.AccountID, amt types.Coins, isLock bool) error
 	CoinsToPower(ctx sdk.Context, from, to types.AccountID, amt types.Coins) error
+	UnLockFreezedCoins(ctx sdk.Context, account types.AccountID, coins types.Coins) error
 
 	GetLockCoins(ctx sdk.Context, account types.AccountID) (types.Coins, []keeper.LockedCoins, error)
 	GetApproveCoins(ctx sdk.Context, account, spender types.AccountID) (*keeper.ApproveData, error)

--- a/x/dex/keeper/keeper.go
+++ b/x/dex/keeper/keeper.go
@@ -3,11 +3,16 @@ package keeper
 import (
 	"fmt"
 
-	assetKeeper "github.com/KuChainNetwork/kuchain/x/asset/keeper"
 	"github.com/KuChainNetwork/kuchain/x/dex/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/libs/log"
+)
+
+type (
+	AccountID = types.AccountID
+	Coins     = types.Coins
+	Coin      = types.Coin
 )
 
 // DexKeeper for asset state
@@ -16,13 +21,13 @@ type DexKeeper struct {
 	key sdk.StoreKey
 	// The codec codec for binary encoding/decoding of accounts.
 	cdc         *codec.Codec
-	assetKeeper assetKeeper.AssetKeeper
+	assetKeeper IAssetKeeper
 }
 
 // NewDexKeeper new keeper for a dex
 func NewDexKeeper(cdc *codec.Codec,
 	key sdk.StoreKey,
-	keeper assetKeeper.AssetKeeper) DexKeeper {
+	keeper IAssetKeeper) DexKeeper {
 	return DexKeeper{
 		key:         key,
 		cdc:         cdc,

--- a/x/dex/keeper/keeper_asset.go
+++ b/x/dex/keeper/keeper_asset.go
@@ -26,6 +26,13 @@ func getCoinsFromKVStore(ctx sdk.Context, cdc *codec.Codec, storeKey types.Store
 
 func setCoinsToKVStore(ctx sdk.Context, cdc *codec.Codec, storeKey types.StoreKey, key []byte, amt Coins) {
 	store := ctx.KVStore(storeKey)
+	if amt.IsZero() {
+		if store.Has(key) {
+			store.Delete(key)
+		}
+		return
+	}
+
 	bz, err := cdc.MarshalBinaryBare(amt)
 	if err != nil {
 		panic(errors.Wrap(err, "marshal dex error"))
@@ -39,28 +46,44 @@ func (k DexKeeper) GetSigInSumForDex(ctx sdk.Context, dex AccountID) Coins {
 	return getCoinsFromKVStore(ctx, k.cdc, k.key, key)
 }
 
-func (k DexKeeper) updateSigInSumForDex(ctx sdk.Context, dex AccountID, amt Coins) error {
+func (k DexKeeper) updateSigInSumForDex(ctx sdk.Context, isSub bool, dex AccountID, amt Coins) error {
 	key := dexTypes.GenStoreKey(dexTypes.DexSigSumStoreKeyPrefix, dex.Bytes())
 	curr := getCoinsFromKVStore(ctx, k.cdc, k.key, key)
 	newCoins := curr.Add(amt...)
-	if newCoins.IsAnyNegative() {
-		return dexTypes.ErrDexSigInChangeToNegative
+	if isSub {
+		n, isNegative := curr.SafeSub(amt)
+		if isNegative {
+			return dexTypes.ErrDexSigInChangeToNegative
+		}
+
+		newCoins = n
 	}
+
 	setCoinsToKVStore(ctx, k.cdc, k.key, key, newCoins)
 	return nil
 }
 
-func (k DexKeeper) updateSigIn(ctx sdk.Context, id, dex AccountID, amt Coins) error {
+func (k DexKeeper) updateSigIn(ctx sdk.Context, isSub bool, id, dex AccountID, amt Coins) (Coins, error) {
 	key := dexTypes.GenStoreKey(dexTypes.DexSigInStoreKeyPrefix, dex.Bytes(), id.Bytes())
 
 	curr := getCoinsFromKVStore(ctx, k.cdc, k.key, key)
 	newCoins := curr.Add(amt...)
-	if newCoins.IsAnyNegative() {
-		return dexTypes.ErrDexSigInChangeToNegative
+	if isSub {
+		n, isNegative := curr.SafeSub(amt)
+		if isNegative {
+			return Coins{}, dexTypes.ErrDexSigInChangeToNegative
+		}
+
+		newCoins = n
 	}
+
 	setCoinsToKVStore(ctx, k.cdc, k.key, key, newCoins)
 
-	return sdkerrors.Wrap(k.updateSigInSumForDex(ctx, dex, amt), "updateSigInSumForDex error")
+	if err := k.updateSigInSumForDex(ctx, isSub, dex, amt); err != nil {
+		return Coins{}, sdkerrors.Wrap(err, "updateSigInSumForDex error")
+	}
+
+	return newCoins, nil
 }
 
 func (k DexKeeper) SigIn(ctx sdk.Context, id, dex AccountID, amt Coins) error {
@@ -69,16 +92,42 @@ func (k DexKeeper) SigIn(ctx sdk.Context, id, dex AccountID, amt Coins) error {
 	}
 
 	// update sigIn state
-	if err := k.updateSigIn(ctx, id, dex, amt); err != nil {
+	curr, err := k.updateSigIn(ctx, false, id, dex, amt)
+	if err != nil {
 		return errors.Wrapf(err, "updateSigIn error")
 	}
 
 	// change asset state
-	if err := k.assetKeeper.Approve(ctx, id, dex, amt, true); err != nil {
+	if err := k.assetKeeper.Approve(ctx, id, dex, curr, true); err != nil {
 		return errors.Wrapf(err, "asset Approve error")
 	}
 
 	if err := k.assetKeeper.LockCoins(ctx, id, -1, amt); err != nil {
+		return errors.Wrapf(err, "asset lock coins error")
+	}
+
+	return nil
+}
+
+func (k DexKeeper) SigOut(ctx sdk.Context, isTimeout bool, id, dex AccountID, amt Coins) error {
+	if _, ok := k.getDex(ctx, dex.MustName()); !ok {
+		return errors.Wrapf(dexTypes.ErrDexNotExists, "dex %s not exists to sigin", dex.String())
+	}
+
+	// TODO: imp isTimeout
+
+	// update sigIn state
+	curr, err := k.updateSigIn(ctx, true, id, dex, amt)
+	if err != nil {
+		return errors.Wrapf(err, "updateSigIn error")
+	}
+
+	// change asset state
+	if err := k.assetKeeper.Approve(ctx, id, dex, curr, true); err != nil {
+		return errors.Wrapf(err, "asset Approve error")
+	}
+
+	if err := k.assetKeeper.UnLockFreezedCoins(ctx, id, amt); err != nil {
 		return errors.Wrapf(err, "asset lock coins error")
 	}
 

--- a/x/dex/keeper/keeper_asset.go
+++ b/x/dex/keeper/keeper_asset.go
@@ -1,0 +1,86 @@
+package keeper
+
+import (
+	"github.com/KuChainNetwork/kuchain/chain/types"
+	dexTypes "github.com/KuChainNetwork/kuchain/x/dex/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/pkg/errors"
+)
+
+func getCoinsFromKVStore(ctx sdk.Context, cdc *codec.Codec, storeKey types.StoreKey, key []byte) Coins {
+	store := ctx.KVStore(storeKey)
+	bz := store.Get(key)
+	if bz == nil {
+		return Coins{}
+	}
+
+	res := Coins{}
+	if err := cdc.UnmarshalBinaryBare(bz, &res); err != nil {
+		panic(errors.Wrap(err, "get coins from data unmarshal"))
+	}
+
+	return res
+}
+
+func setCoinsToKVStore(ctx sdk.Context, cdc *codec.Codec, storeKey types.StoreKey, key []byte, amt Coins) {
+	store := ctx.KVStore(storeKey)
+	bz, err := cdc.MarshalBinaryBare(amt)
+	if err != nil {
+		panic(errors.Wrap(err, "marshal dex error"))
+	}
+
+	store.Set(key, bz)
+}
+
+func (k DexKeeper) GetSigInSumForDex(ctx sdk.Context, dex AccountID) Coins {
+	key := dexTypes.GenStoreKey(dexTypes.DexSigSumStoreKeyPrefix, dex.Bytes())
+	return getCoinsFromKVStore(ctx, k.cdc, k.key, key)
+}
+
+func (k DexKeeper) updateSigInSumForDex(ctx sdk.Context, dex AccountID, amt Coins) error {
+	key := dexTypes.GenStoreKey(dexTypes.DexSigSumStoreKeyPrefix, dex.Bytes())
+	curr := getCoinsFromKVStore(ctx, k.cdc, k.key, key)
+	newCoins := curr.Add(amt...)
+	if newCoins.IsAnyNegative() {
+		return dexTypes.ErrDexSigInChangeToNegative
+	}
+	setCoinsToKVStore(ctx, k.cdc, k.key, key, newCoins)
+	return nil
+}
+
+func (k DexKeeper) updateSigIn(ctx sdk.Context, id, dex AccountID, amt Coins) error {
+	key := dexTypes.GenStoreKey(dexTypes.DexSigInStoreKeyPrefix, dex.Bytes(), id.Bytes())
+
+	curr := getCoinsFromKVStore(ctx, k.cdc, k.key, key)
+	newCoins := curr.Add(amt...)
+	if newCoins.IsAnyNegative() {
+		return dexTypes.ErrDexSigInChangeToNegative
+	}
+	setCoinsToKVStore(ctx, k.cdc, k.key, key, newCoins)
+
+	return sdkerrors.Wrap(k.updateSigInSumForDex(ctx, dex, amt), "updateSigInSumForDex error")
+}
+
+func (k DexKeeper) SigIn(ctx sdk.Context, id, dex AccountID, amt Coins) error {
+	if _, ok := k.getDex(ctx, dex.MustName()); !ok {
+		return errors.Wrapf(dexTypes.ErrDexNotExists, "dex %s not exists to sigin", dex.String())
+	}
+
+	// update sigIn state
+	if err := k.updateSigIn(ctx, id, dex, amt); err != nil {
+		return errors.Wrapf(err, "updateSigIn error")
+	}
+
+	// change asset state
+	if err := k.assetKeeper.Approve(ctx, id, dex, amt, true); err != nil {
+		return errors.Wrapf(err, "asset Approve error")
+	}
+
+	if err := k.assetKeeper.LockCoins(ctx, id, -1, amt); err != nil {
+		return errors.Wrapf(err, "asset lock coins error")
+	}
+
+	return nil
+}

--- a/x/dex/types/codec.go
+++ b/x/dex/types/codec.go
@@ -18,6 +18,9 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(&MsgUpdateDexDescriptionData{}, "dex/MsgUpdateDexDescriptionData", nil)
 	cdc.RegisterConcrete(&MsgDestroyDex{}, "dex/MsgDestroyDex", nil)
 	cdc.RegisterConcrete(&MsgDestroyDexData{}, "dex/MsgDestroyDexData", nil)
+
+	cdc.RegisterConcrete(&MsgDexSigIn{}, "dex/sigin", nil)
+	cdc.RegisterConcrete(&MsgDexSigInData{}, "dex/siginData", nil)
 }
 
 func init() {

--- a/x/dex/types/codec.go
+++ b/x/dex/types/codec.go
@@ -21,6 +21,8 @@ func RegisterCodec(cdc *codec.Codec) {
 
 	cdc.RegisterConcrete(&MsgDexSigIn{}, "dex/sigin", nil)
 	cdc.RegisterConcrete(&MsgDexSigInData{}, "dex/siginData", nil)
+	cdc.RegisterConcrete(&MsgDexSigOut{}, "dex/sigout", nil)
+	cdc.RegisterConcrete(&MsgDexSigOutData{}, "dex/sigoutData", nil)
 }
 
 func init() {

--- a/x/dex/types/errors.go
+++ b/x/dex/types/errors.go
@@ -12,3 +12,7 @@ var (
 	ErrDexStakingsNotMatch  = sdkerrors.Register(ModuleName, 5, "dex stakings not match")
 	ErrDexWasDestroy        = sdkerrors.Register(ModuleName, 6, "dex was destroy")
 )
+
+var (
+	ErrDexSigInChangeToNegative = sdkerrors.Register(ModuleName, 7, "dex sigIn amt should cannot tobe changed to negative")
+)

--- a/x/dex/types/events.go
+++ b/x/dex/types/events.go
@@ -8,7 +8,10 @@ const (
 	EventTypeCreateDex            = "createDex"
 	EventTypeUpdateDexDescription = "updateDexDescription"
 	EventTypeDestroyDex           = "destroyDex"
+	EventTypeDexSigIn             = "dexSigIn"
 )
+
+// TODO: use one in all modules
 
 const (
 	AttributeKeyFrom          = "from"
@@ -25,4 +28,6 @@ const (
 	AttributeKeyIssueToHeight = "issueToHeight"
 	AttributeKeyInit          = "init"
 	AttributeKeyDescription   = "desc"
+	AttributeKeyUser          = "user"
+	AttributeKeyDex           = "dex"
 )

--- a/x/dex/types/events.go
+++ b/x/dex/types/events.go
@@ -9,6 +9,7 @@ const (
 	EventTypeUpdateDexDescription = "updateDexDescription"
 	EventTypeDestroyDex           = "destroyDex"
 	EventTypeDexSigIn             = "dexSigIn"
+	EventTypeDexSigOut            = "dexSigOut"
 )
 
 // TODO: use one in all modules
@@ -30,4 +31,5 @@ const (
 	AttributeKeyDescription   = "desc"
 	AttributeKeyUser          = "user"
 	AttributeKeyDex           = "dex"
+	AttributeKeyIsTimeout     = "isTimeout"
 )

--- a/x/dex/types/keys.go
+++ b/x/dex/types/keys.go
@@ -34,9 +34,11 @@ var (
 	// ModuleDexKeyPrefix prefix for asset store
 	ModuleDexKeyPrefix = []byte{0x0B}
 
-	DexStoreKeyPrefix = MustName("dex").Bytes()
-
 	DexNumberStoreKey = MustName("dex.number").Bytes()
+
+	DexStoreKeyPrefix       = MustName("dex").Bytes()
+	DexSigInStoreKeyPrefix  = MustName("dex.sigin").Bytes()
+	DexSigSumStoreKeyPrefix = MustName("dex.sigsum").Bytes()
 )
 
 func Logger(ctx sdk.Context) log.Logger {
@@ -53,6 +55,10 @@ func genStoreKey(pre []byte, keys ...[]byte) []byte {
 	return res
 }
 
+func GenStoreKey(pre []byte, keys ...[]byte) []byte {
+	return genStoreKey(pre, keys...)
+}
+
 // DexStoreKey get the key of coin state store keeper for asset
 func DexStoreKey(creator Name) []byte {
 	return genStoreKey(DexStoreKeyPrefix, creator.Bytes())
@@ -60,5 +66,5 @@ func DexStoreKey(creator Name) []byte {
 
 // GetNumberStoreKey get the key of next dex number
 func GetDexNumberStoreKey() []byte {
-	return genStoreKey(DexStoreKeyPrefix, DexNumberStoreKey)
+	return genStoreKey(DexNumberStoreKey)
 }

--- a/x/dex/types/msg_asset.go
+++ b/x/dex/types/msg_asset.go
@@ -1,0 +1,76 @@
+package types
+
+import (
+	"github.com/KuChainNetwork/kuchain/chain/msg"
+	"github.com/KuChainNetwork/kuchain/chain/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+type MsgDexSigIn struct {
+	types.KuMsg
+}
+
+type MsgDexSigInData struct {
+	User   AccountID `json:"user" yaml:"user"`
+	Dex    AccountID `json:"dex" yaml:"dex"`
+	Amount Coins     `json:"amount" yaml:"amount"`
+}
+
+// Type imp for data KuMsgData
+func (MsgDexSigInData) Type() types.Name { return types.MustName("sigin") }
+
+func (msg MsgDexSigInData) Sender() AccountID {
+	return msg.User
+}
+
+// NewMsgDexSigIn new dex sig in msg
+func NewMsgDexSigIn(auth types.AccAddress, user, dex AccountID, amount Coins) MsgDexSigIn {
+	return MsgDexSigIn{
+		*msg.MustNewKuMsg(
+			RouterKeyName,
+			msg.WithAuth(auth),
+			msg.WithData(Cdc(), &MsgDexSigInData{
+				User:   user,
+				Dex:    dex,
+				Amount: amount,
+			}),
+		),
+	}
+}
+
+func (msg MsgDexSigIn) GetData() (MsgDexSigInData, error) {
+	res := MsgDexSigInData{}
+	if err := msg.UnmarshalData(Cdc(), &res); err != nil {
+		return MsgDexSigInData{}, sdkerrors.Wrapf(types.ErrKuMsgDataUnmarshal, "%s", err.Error())
+	}
+	return res, nil
+}
+
+func (msg MsgDexSigIn) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
+		return err
+	}
+
+	data, err := msg.GetData()
+	if err != nil {
+		return err
+	}
+
+	if data.User.Empty() {
+		return sdkerrors.Wrap(types.ErrKuMsgAccountIDNil, "user accountID empty")
+	}
+
+	if data.Dex.Empty() {
+		return sdkerrors.Wrap(types.ErrKuMsgAccountIDNil, "dex accountID empty")
+	}
+
+	if data.User.Eq(data.Dex) {
+		return sdkerrors.Wrap(types.ErrKuMsgSpenderShouldNotEqual, "dex should not be equal to user")
+	}
+
+	if data.Amount.IsAnyNegative() {
+		return types.ErrKuMsgCoinsHasNegative
+	}
+
+	return nil
+}

--- a/x/dex/types/msg_asset.go
+++ b/x/dex/types/msg_asset.go
@@ -74,3 +74,74 @@ func (msg MsgDexSigIn) ValidateBasic() error {
 
 	return nil
 }
+
+type MsgDexSigOut struct {
+	types.KuMsg
+}
+
+type MsgDexSigOutData struct {
+	User      AccountID `json:"user" yaml:"user"`
+	Dex       AccountID `json:"dex" yaml:"dex"`
+	Amount    Coins     `json:"amount" yaml:"amount"`
+	IsTimeout bool      `json:"is_timeout" yaml:"is_timeout"`
+}
+
+// Type imp for data KuMsgData
+func (MsgDexSigOutData) Type() types.Name { return types.MustName("sigout") }
+
+func (msg MsgDexSigOutData) Sender() AccountID {
+	return msg.User
+}
+
+// NewMsgDexSigOut new dex sig in msg
+func NewMsgDexSigOut(auth types.AccAddress, isTimeout bool, user, dex AccountID, amount Coins) MsgDexSigOut {
+	return MsgDexSigOut{
+		*msg.MustNewKuMsg(
+			RouterKeyName,
+			msg.WithAuth(auth),
+			msg.WithData(Cdc(), &MsgDexSigOutData{
+				User:      user,
+				Dex:       dex,
+				Amount:    amount,
+				IsTimeout: isTimeout,
+			}),
+		),
+	}
+}
+
+func (msg MsgDexSigOut) GetData() (MsgDexSigOutData, error) {
+	res := MsgDexSigOutData{}
+	if err := msg.UnmarshalData(Cdc(), &res); err != nil {
+		return MsgDexSigOutData{}, sdkerrors.Wrapf(types.ErrKuMsgDataUnmarshal, "%s", err.Error())
+	}
+	return res, nil
+}
+
+func (msg MsgDexSigOut) ValidateBasic() error {
+	if err := msg.KuMsg.ValidateTransfer(); err != nil {
+		return err
+	}
+
+	data, err := msg.GetData()
+	if err != nil {
+		return err
+	}
+
+	if data.User.Empty() {
+		return sdkerrors.Wrap(types.ErrKuMsgAccountIDNil, "user accountID empty")
+	}
+
+	if data.Dex.Empty() {
+		return sdkerrors.Wrap(types.ErrKuMsgAccountIDNil, "dex accountID empty")
+	}
+
+	if data.User.Eq(data.Dex) {
+		return sdkerrors.Wrap(types.ErrKuMsgSpenderShouldNotEqual, "dex should not be equal to user")
+	}
+
+	if data.Amount.IsAnyNegative() {
+		return types.ErrKuMsgCoinsHasNegative
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Add SigIn and SigOut For Dex.

## Introduction

SigIn and SigOut is two basic privime in dex asset transfer.

User can approve and lock its token to dex to sell ot buy order.

## Modifys

- Add SigIn imp
- Add SigOut imp
- Fix some problems in lock and approve

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes