### PR TITLE
SigOut By user

### DIFF
--- a/x/dex/handler.go
+++ b/x/dex/handler.go
@@ -408,8 +408,6 @@ func handleMsgDexSigOut(ctx chainTypes.Context, k Keeper, msg *types.MsgDexSigOu
 		"user", msgData.User, "dex", msgData.Dex, "amount", msgData.Amount, "isTimeout", msgData.IsTimeout)
 
 	// Note: two mode, if just has user's auth, need to wait
-	// TODO: wait mode
-
 	if msgData.IsTimeout {
 		ctx.RequireAuth(msgData.User)
 	} else {

--- a/x/dex/handler_signin_test.go
+++ b/x/dex/handler_signin_test.go
@@ -35,22 +35,26 @@ func SignInMsgForTest(t *testing.T, app *simapp.SimApp, isSuccess bool, id, dex 
 }
 
 func SignOutMsgByDexForTest(t *testing.T, app *simapp.SimApp, isSuccess bool, id, dex types.AccountID, amount types.Coins) error {
+	return SignOutMsgByDexExForTest(t, app, app.NewTestContext(), isSuccess, dex, id, dex, amount)
+}
+
+func SignOutMsgByDexExForTest(t *testing.T, app *simapp.SimApp, ctx sdk.Context, isSuccess bool, sigUser, id, dex types.AccountID, amount types.Coins) error {
 	wallet := app.GetWallet()
 
-	ctx := app.NewTestContext()
+	isByUser := id.Eq(sigUser)
 
 	msg := dexTypes.NewMsgDexSigOut(
-		wallet.GetAuth(dex),
-		false,
+		wallet.GetAuth(sigUser),
+		isByUser,
 		id,
 		dex,
 		amount)
 
 	tx := simapp.NewTxForTest(
-		dex,
+		sigUser,
 		[]sdk.Msg{
 			&msg,
-		}, wallet.PrivKey(wallet.GetAuth(dex)))
+		}, wallet.PrivKey(wallet.GetAuth(sigUser)))
 
 	if !isSuccess {
 		tx = tx.WithCannotPass()

--- a/x/dex/handler_sigout_test.go
+++ b/x/dex/handler_sigout_test.go
@@ -76,3 +76,67 @@ func TestSigoutByUser(t *testing.T) {
 		So(data, ShouldBeNil)
 	})
 }
+
+func TestSigoutByUserThanDexSigout(t *testing.T) {
+	Convey("test signOut msg by user", t, func() {
+		app, _ := createAppForTest()
+
+		So(CreateDexForTest(t, app, true, dexAccount1, types.NewInt64CoreCoins(1000000000), []byte("dex for test")), ShouldBeNil)
+
+		amt := types.NewInt64CoreCoins(1000000)
+		So(SignInMsgForTest(t, app, true, account1, dexAccount1, amt), ShouldBeNil)
+
+		ctx := app.NewTestContext()
+		assetKeeper := app.AssetKeeper()
+
+		data, err := assetKeeper.GetApproveCoins(ctx, account1, dexAccount1)
+		So(err, ShouldBeNil)
+		So(data, ShouldNotBeNil)
+		So(data.IsLock, ShouldBeTrue)
+		So(data.Amount, simapp.ShouldEq, amt)
+
+		out := types.NewInt64CoreCoins(77777)
+		left := amt.Sub(out)
+		// sigout req
+		So(SignOutMsgByDexExForTest(t, app, ctx, true, account1, account1, dexAccount1, out), ShouldBeNil)
+
+		ctx = app.NewTestContext()
+		height, ok := app.DexKeeper().GetSigOutReqHeight(ctx, account1)
+		So(ok, ShouldBeTrue)
+		So(height, ShouldEqual, app.LastBlockHeight())
+
+		// req two times, should error
+		So(SignOutMsgByDexExForTest(t, app, ctx, false, account1, account1, dexAccount1, out),
+			simapp.ShouldErrIs, dexTypes.ErrDexSigOutByUserNoUnlock)
+
+		// wait no enough blocks
+		simapp.AfterBlockCommitted(app, 1)
+
+		ctx = app.NewTestContext()
+		app.Logger().Info("current block", "height", ctx.BlockHeight())
+
+		// should ok
+		So(SignOutMsgByDexForTest(t, app, true, account1, dexAccount1, out), ShouldBeNil)
+
+		ctx = app.NewTestContext()
+
+		data, err = assetKeeper.GetApproveCoins(ctx, account1, dexAccount1)
+		So(err, ShouldBeNil)
+		So(data, ShouldNotBeNil)
+		So(data.IsLock, ShouldBeTrue)
+		So(data.Amount, simapp.ShouldEq, left)
+
+		// should clean sigout
+		height, ok = app.DexKeeper().GetSigOutReqHeight(ctx, account1)
+		So(ok, ShouldBeFalse)
+		So(height, ShouldEqual, 0)
+
+		So(SignOutMsgByDexForTest(t, app, true, account1, dexAccount1, left), ShouldBeNil)
+
+		ctx = app.NewTestContext()
+
+		data, err = assetKeeper.GetApproveCoins(ctx, account1, dexAccount1)
+		So(err, ShouldBeNil)
+		So(data, ShouldBeNil)
+	})
+}

--- a/x/dex/handler_sigout_test.go
+++ b/x/dex/handler_sigout_test.go
@@ -1,0 +1,78 @@
+package dex_test
+
+import (
+	"testing"
+
+	"github.com/KuChainNetwork/kuchain/chain/types"
+	"github.com/KuChainNetwork/kuchain/test/simapp"
+	"github.com/KuChainNetwork/kuchain/x/dex/keeper"
+	dexTypes "github.com/KuChainNetwork/kuchain/x/dex/types"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSigoutByUser(t *testing.T) {
+	Convey("test signOut msg by user", t, func() {
+		// change var
+		keeper.SigOutByUserUnlockHeight = 10
+
+		app, _ := createAppForTest()
+
+		So(CreateDexForTest(t, app, true, dexAccount1, types.NewInt64CoreCoins(1000000000), []byte("dex for test")), ShouldBeNil)
+
+		amt := types.NewInt64CoreCoins(1000000)
+		So(SignInMsgForTest(t, app, true, account1, dexAccount1, amt), ShouldBeNil)
+
+		ctx := app.NewTestContext()
+		assetKeeper := app.AssetKeeper()
+
+		data, err := assetKeeper.GetApproveCoins(ctx, account1, dexAccount1)
+		So(err, ShouldBeNil)
+		So(data, ShouldNotBeNil)
+		So(data.IsLock, ShouldBeTrue)
+		So(data.Amount, simapp.ShouldEq, amt)
+
+		out := types.NewInt64CoreCoins(77777)
+		left := amt.Sub(out)
+		// sigout req
+		So(SignOutMsgByDexExForTest(t, app, ctx, true, account1, account1, dexAccount1, out), ShouldBeNil)
+
+		ctx = app.NewTestContext()
+		height, ok := app.DexKeeper().GetSigOutReqHeight(ctx, account1)
+		So(ok, ShouldBeTrue)
+		So(height, ShouldEqual, app.LastBlockHeight())
+
+		// req two times, should error
+		So(SignOutMsgByDexExForTest(t, app, ctx, false, account1, account1, dexAccount1, out),
+			simapp.ShouldErrIs, dexTypes.ErrDexSigOutByUserNoUnlock)
+
+		// wait enough blocks
+		simapp.AfterBlockCommitted(app, int(keeper.SigOutByUserUnlockHeight))
+
+		ctx = app.NewTestContext()
+		app.Logger().Info("current block", "height", ctx.BlockHeight())
+
+		// should ok
+		So(SignOutMsgByDexExForTest(t, app, ctx, true, account1, account1, dexAccount1, out), ShouldBeNil)
+
+		ctx = app.NewTestContext()
+
+		data, err = assetKeeper.GetApproveCoins(ctx, account1, dexAccount1)
+		So(err, ShouldBeNil)
+		So(data, ShouldNotBeNil)
+		So(data.IsLock, ShouldBeTrue)
+		So(data.Amount, simapp.ShouldEq, left)
+
+		// should clean sigout
+		height, ok = app.DexKeeper().GetSigOutReqHeight(ctx, account1)
+		So(ok, ShouldBeFalse)
+		So(height, ShouldEqual, 0)
+
+		So(SignOutMsgByDexForTest(t, app, true, account1, dexAccount1, left), ShouldBeNil)
+
+		ctx = app.NewTestContext()
+
+		data, err = assetKeeper.GetApproveCoins(ctx, account1, dexAccount1)
+		So(err, ShouldBeNil)
+		So(data, ShouldBeNil)
+	})
+}

--- a/x/dex/keeper/consts.go
+++ b/x/dex/keeper/consts.go
@@ -1,0 +1,6 @@
+package keeper
+
+const (
+	// equal 7 days
+	SigOutByUserUnlockHeight int64 = 7 * 24 * 1200
+)

--- a/x/dex/keeper/consts.go
+++ b/x/dex/keeper/consts.go
@@ -1,6 +1,6 @@
 package keeper
 
-const (
+var (
 	// equal 7 days
 	SigOutByUserUnlockHeight int64 = 7 * 24 * 1200
 )

--- a/x/dex/keeper/keeper_asset.go
+++ b/x/dex/keeper/keeper_asset.go
@@ -179,7 +179,7 @@ func (k DexKeeper) SigOut(ctx sdk.Context, isTimeout bool, id, dex AccountID, am
 			k.setSigOutReqHeightToStore(ctx, id, 0)
 		} else {
 			return errors.Wrapf(dexTypes.ErrDexSigOutByUserNoUnlock,
-				"sigOut by user need wait to %d", reqHeight+SigOutByUserUnlockHeight)
+				"sigOut by user need wait to %d but %d", reqHeight+SigOutByUserUnlockHeight, ctx.BlockHeight())
 		}
 	} else {
 		// if has req, but sigout by dex

--- a/x/dex/keeper/keeper_asset.go
+++ b/x/dex/keeper/keeper_asset.go
@@ -110,12 +110,84 @@ func (k DexKeeper) SigIn(ctx sdk.Context, id, dex AccountID, amt Coins) error {
 	return nil
 }
 
+func (k DexKeeper) GetSigOutReqHeight(ctx sdk.Context, id AccountID) (int64, bool) {
+	key := dexTypes.DexSigOutReqStoreKey(id)
+
+	store := ctx.KVStore(k.key)
+
+	if !store.Has(key) {
+		return 0, false
+	}
+
+	bz := store.Get(key)
+	if bz == nil {
+		return 0, false
+	}
+
+	var res int64
+	if err := k.cdc.UnmarshalBinaryBare(bz, &res); err != nil {
+		panic(errors.Wrap(err, "get height error from data unmarshal"))
+	}
+
+	return res, res > 0
+}
+
+func (k DexKeeper) setSigOutReqHeightToStore(ctx sdk.Context, id AccountID, height int64) {
+	key := dexTypes.DexSigOutReqStoreKey(id)
+
+	store := ctx.KVStore(k.key)
+
+	// cleanup sigout req
+	if height == 0 {
+		if store.Has(key) {
+			store.Delete(key)
+		}
+		return
+	}
+
+	if store.Has(key) {
+		panic(errors.Errorf("cannot update req height"))
+	}
+
+	bz, err := k.cdc.MarshalBinaryBare(height)
+	if err != nil {
+		panic(errors.Wrap(err, "marshal dex error"))
+	}
+
+	store.Set(key, bz)
+}
+
 func (k DexKeeper) SigOut(ctx sdk.Context, isTimeout bool, id, dex AccountID, amt Coins) error {
 	if _, ok := k.getDex(ctx, dex.MustName()); !ok {
 		return errors.Wrapf(dexTypes.ErrDexNotExists, "dex %s not exists to sigin", dex.String())
 	}
 
-	// TODO: imp isTimeout
+	if isTimeout {
+		reqHeight, ok := k.GetSigOutReqHeight(ctx, id)
+
+		// if not has req, set req height
+		if !ok {
+			k.setSigOutReqHeightToStore(ctx, id, ctx.BlockHeight())
+			// just return
+			return nil
+		}
+
+		// is has req, so check if current height >= (reqHeight + unlockHeight)
+		// has req, but not ok, so error
+		if ctx.BlockHeight() >= (reqHeight + SigOutByUserUnlockHeight) {
+			// cleanup req
+			k.setSigOutReqHeightToStore(ctx, id, 0)
+		} else {
+			return errors.Wrapf(dexTypes.ErrDexSigOutByUserNoUnlock,
+				"sigOut by user need wait to %d", reqHeight+SigOutByUserUnlockHeight)
+		}
+	} else {
+		// if has req, but sigout by dex
+		if _, ok := k.GetSigOutReqHeight(ctx, id); ok {
+			// cleanup req
+			k.setSigOutReqHeightToStore(ctx, id, 0)
+		}
+	}
 
 	// update sigIn state
 	curr, err := k.updateSigIn(ctx, true, id, dex, amt)

--- a/x/dex/types/errors.go
+++ b/x/dex/types/errors.go
@@ -24,4 +24,5 @@ var (
 
 var (
 	ErrDexSigInChangeToNegative = sdkerrors.Register(ModuleName, 16, "dex sigIn amt should cannot tobe changed to negative")
+	ErrDexSigOutByUserNoUnlock  = sdkerrors.Register(ModuleName, 17, "dex sig out by user is locked in current")
 )

--- a/x/dex/types/keys.go
+++ b/x/dex/types/keys.go
@@ -36,9 +36,10 @@ var (
 
 	DexNumberStoreKey = MustName("dex.number").Bytes()
 
-	DexStoreKeyPrefix       = MustName("dex").Bytes()
-	DexSigInStoreKeyPrefix  = MustName("dex.sigin").Bytes()
-	DexSigSumStoreKeyPrefix = MustName("dex.sigsum").Bytes()
+	DexStoreKeyPrefix          = MustName("dex").Bytes()
+	DexSigInStoreKeyPrefix     = MustName("dex.sigin").Bytes()
+	DexSigSumStoreKeyPrefix    = MustName("dex.sigsum").Bytes()
+	DexSigOutReqStoreKeyPrefix = MustName("dex.sigoutreq").Bytes()
 )
 
 func Logger(ctx sdk.Context) log.Logger {
@@ -67,4 +68,9 @@ func DexStoreKey(creator Name) []byte {
 // GetNumberStoreKey get the key of next dex number
 func GetDexNumberStoreKey() []byte {
 	return genStoreKey(DexNumberStoreKey)
+}
+
+// DexSigOutReqStoreKey get the key of coin state store keeper for asset
+func DexSigOutReqStoreKey(user AccountID) []byte {
+	return genStoreKey(DexSigOutReqStoreKeyPrefix, user.Bytes())
 }


### PR DESCRIPTION
## Summary

add Sigout by user functional in sigout.

## Introduction

If a dex not process sigout request, user can sigout by self, but need to wait for 7 days.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes