### PR TITLE
Refactor logger in kratos

### DIFF
--- a/chain/lcd/root.go
+++ b/chain/lcd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
 	tmrpcserver "github.com/tendermint/tendermint/rpc/jsonrpc/server"
 
@@ -33,7 +34,7 @@ type RestServer struct {
 func NewRestServer(cdc *codec.Codec) *RestServer {
 	r := mux.NewRouter()
 	cliCtx := context.NewCLIContext().WithCodec(cdc)
-	logger := kuLog.NewLoggerByZap(false).With("module", "rest-server")
+	logger := kuLog.NewLoggerByZap(viper.GetBool(cli.TraceFlag), viper.GetString("log_level")).With("module", "rest-server")
 
 	return &RestServer{
 		Mux:    r,

--- a/cmd/kucd/main.go
+++ b/cmd/kucd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/version"
 
 	//"github.com/KuChainNetwork/kuchain/x/staking"
 	"github.com/spf13/cobra"
@@ -49,7 +50,7 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:               "kucd",
 		Short:             "kuchain Daemon (server)",
-		PersistentPreRunE: kuLog.PersistentPreRunEFn(ctx),
+		PersistentPreRunE: persistentPreRunEFn(ctx),
 	}
 
 	rootCmd.AddCommand(genutilcli.InitCmd(ctx, genCdc, app.ModuleBasics, app.DefaultNodeHome))
@@ -136,4 +137,16 @@ func exportAppStateAndTMValidators(
 
 	kuApp := app.NewKuchainApp(logger, db, traceStore, true, uint(1))
 	return kuApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
+}
+
+func persistentPreRunEFn(context *server.Context) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if cmd.Name() == version.Cmd.Name() {
+			return nil
+		}
+
+		context.Logger = kuLog.NewLoggerByZap(viper.GetBool(cli.TraceFlag)).With("module", "main")
+		context.Config = chainCfg.DefaultConfig()
+		return nil
+	}
 }

--- a/cmd/kucd/main.go
+++ b/cmd/kucd/main.go
@@ -145,7 +145,9 @@ func persistentPreRunEFn(context *server.Context) func(*cobra.Command, []string)
 			return nil
 		}
 
-		context.Logger = kuLog.NewLoggerByZap(viper.GetBool(cli.TraceFlag)).With("module", "main")
+		context.Logger = kuLog.NewLoggerByZap(
+			viper.GetBool(cli.TraceFlag),
+			viper.GetString("log_level")).With("module", "main")
 		context.Config = chainCfg.DefaultConfig()
 		return nil
 	}

--- a/utils/log/cmds.go
+++ b/utils/log/cmds.go
@@ -9,15 +9,26 @@ import (
 	tmlog "github.com/tendermint/tendermint/libs/log"
 )
 
-func NewLoggerByZap(isTrace bool) tmlog.Logger {
-	zapLogger := mkZapLogger(viper.GetBool(cli.TraceFlag))
+const (
+	// for kratos, it need caller skip 2 by logger.Info and filter.
+	callerSkipLevelNum = 2
+)
 
-	// process log level for cosmos-sdk
-	logLvCfg := viper.GetString("log_level")
-	logger, err := tmflags.ParseLogLevel(logLvCfg, NewLogger(zapLogger), cfg.DefaultLogLevel())
+func NewLoggerByZap(isTrace bool, logLevelStr string) tmlog.Logger {
+
+	zapLogger := NewZapLogger(viper.GetBool(cli.TraceFlag))
+
+	// warp zap log to logger, it will add caller skip 1
+	logger := NewLogger(zapLogger)
+
+	// add caller skip by 2, as warp and level log
+	logger = logger.WithCallerSkip(callerSkipLevelNum)
+
+	// process log level for cosmos-sdk, , it will add caller skip 1
+	loggerByLevel, err := tmflags.ParseLogLevel(logLevelStr, logger, cfg.DefaultLogLevel())
 	if err != nil {
 		panic(err)
 	}
 
-	return logger
+	return loggerByLevel
 }

--- a/utils/log/cmds.go
+++ b/utils/log/cmds.go
@@ -1,33 +1,13 @@
 package log
 
 import (
-	"fmt"
-
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-
-	chainCfg "github.com/KuChainNetwork/kuchain/chain/config"
-	"github.com/cosmos/cosmos-sdk/server"
-	"github.com/cosmos/cosmos-sdk/version"
-	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
 	tmflags "github.com/tendermint/tendermint/libs/cli/flags"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 )
-
-func PersistentPreRunEFn(context *server.Context) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		if cmd.Name() == version.Cmd.Name() {
-			return nil
-		}
-
-		context.Logger = NewLoggerByZap(viper.GetBool(cli.TraceFlag)).With("module", "main")
-		context.Config = chainCfg.DefaultConfig()
-		return nil
-	}
-}
 
 func NewLoggerByZap(isTrace bool) tmlog.Logger {
 	zapLogger := mkZapLogger(viper.GetBool(cli.TraceFlag))
@@ -40,38 +20,4 @@ func NewLoggerByZap(isTrace bool) tmlog.Logger {
 	}
 
 	return logger
-}
-
-func mkZapLogger(isDebug bool) *zap.Logger {
-	encoderConfig := zapcore.EncoderConfig{
-		TimeKey:        "tm",
-		LevelKey:       "lv",
-		NameKey:        "logger",
-		CallerKey:      "caller",
-		MessageKey:     "msg",
-		StacktraceKey:  "stacktrace",
-		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeTime:     zapcore.EpochNanosTimeEncoder,
-		EncodeLevel:    zapcore.LowercaseLevelEncoder,
-		EncodeDuration: zapcore.SecondsDurationEncoder,
-		EncodeCaller:   zapcore.ShortCallerEncoder,
-	}
-
-	if isDebug {
-		encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-		encoderConfig.EncodeCaller = zapcore.FullCallerEncoder
-	}
-
-	config := zap.NewDevelopmentConfig()
-
-	config.Level = zap.NewAtomicLevelAt(zap.DebugLevel) // most small
-	config.EncoderConfig = encoderConfig
-	config.Development = isDebug
-
-	logger, err := config.Build()
-	if err != nil {
-		panic(fmt.Sprintf("zap logger build err by %s", err.Error()))
-	}
-
-	return logger.WithOptions(zap.AddCallerSkip(2))
 }

--- a/utils/log/logger.go
+++ b/utils/log/logger.go
@@ -92,3 +92,9 @@ func (l *Logger) With(keyvals ...interface{}) tmlog.Logger {
 		logger: l.logger.With(fields...),
 	}
 }
+
+// WithCallerSkip if warp the log, to add the caller skip to show the right caller
+func (l *Logger) WithCallerSkip(skip int) *Logger {
+	l.logger = l.logger.WithOptions(zap.AddCallerSkip(skip))
+	return l
+}

--- a/utils/log/logger_test.go
+++ b/utils/log/logger_test.go
@@ -1,13 +1,31 @@
 package log
 
 import (
+	"fmt"
+
 	"testing"
+
+	tmlog "github.com/tendermint/tendermint/libs/log"
 )
 
 func TestNewLogger(t *testing.T) {
-	l := mkZapLogger(false)
-	logger := NewLogger(l)
+	logger := NewLogger(NewZapLogger(false)).WithCallerSkip(1) // for warp
 	defer logger.Flush()
 
-	logger.Info("hello", "v", "isOk", "i", 223)
+	var ll tmlog.Logger = logger
+
+	ll.Info("hello", "v", "isOk", "i", 223)
+}
+
+func logWarp(l tmlog.Logger, format string, args ...interface{}) {
+	l.Info(fmt.Sprintf(format, args...), "warped", "ok")
+}
+
+func TestLoggerWarp(t *testing.T) {
+	logger := NewLogger(NewZapLogger(false))
+	defer logger.Flush()
+
+	var ll tmlog.Logger = logger.WithCallerSkip(2)
+
+	logWarp(ll, "log in there %s", "curr")
 }

--- a/utils/log/zap.go
+++ b/utils/log/zap.go
@@ -7,13 +7,14 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func mkZapLogger(isDebug bool) *zap.Logger {
+// NewZapLogger create a logger by zap
+func NewZapLogger(isDebug bool) *zap.Logger {
 	encoderConfig := zapcore.EncoderConfig{
-		TimeKey:        "tm",
-		LevelKey:       "lv",
+		TimeKey:        "logTm",
+		LevelKey:       "logLv",
 		NameKey:        "logger",
 		CallerKey:      "caller",
-		MessageKey:     "msg",
+		MessageKey:     "logMsg",
 		StacktraceKey:  "stacktrace",
 		LineEnding:     zapcore.DefaultLineEnding,
 		EncodeTime:     zapcore.EpochNanosTimeEncoder,
@@ -27,7 +28,11 @@ func mkZapLogger(isDebug bool) *zap.Logger {
 		encoderConfig.EncodeCaller = zapcore.FullCallerEncoder
 	}
 
-	config := zap.NewDevelopmentConfig()
+	config := zap.NewProductionConfig()
+
+	if isDebug {
+		config = zap.NewDevelopmentConfig()
+	}
 
 	config.Level = zap.NewAtomicLevelAt(zap.DebugLevel) // most small
 	config.EncoderConfig = encoderConfig
@@ -38,5 +43,5 @@ func mkZapLogger(isDebug bool) *zap.Logger {
 		panic(fmt.Sprintf("zap logger build err by %s", err.Error()))
 	}
 
-	return logger.WithOptions(zap.AddCallerSkip(2))
+	return logger
 }

--- a/utils/log/zap.go
+++ b/utils/log/zap.go
@@ -1,0 +1,42 @@
+package log
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func mkZapLogger(isDebug bool) *zap.Logger {
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:        "tm",
+		LevelKey:       "lv",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "msg",
+		StacktraceKey:  "stacktrace",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeTime:     zapcore.EpochNanosTimeEncoder,
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
+
+	if isDebug {
+		encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+		encoderConfig.EncodeCaller = zapcore.FullCallerEncoder
+	}
+
+	config := zap.NewDevelopmentConfig()
+
+	config.Level = zap.NewAtomicLevelAt(zap.DebugLevel) // most small
+	config.EncoderConfig = encoderConfig
+	config.Development = isDebug
+
+	logger, err := config.Build()
+	if err != nil {
+		panic(fmt.Sprintf("zap logger build err by %s", err.Error()))
+	}
+
+	return logger.WithOptions(zap.AddCallerSkip(2))
+}


### PR DESCRIPTION
## Summary

Refactor logger support in kratos.

## Modifys

- Make logger create function for both zap and logger
- Add CallerSkip support for logger

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes