### PR TITLE
Fix Support For export genesis status for kratos

### DIFF
--- a/chain/types/account_id.go
+++ b/chain/types/account_id.go
@@ -347,15 +347,19 @@ func (a AccountID) MustName() Name {
 	return res
 }
 
-// NewAccountIDFromStoreKey creates a new accountID from store key
+// NewAccountIDFromStoreKey creates a new accountID from store key, skip the first prefix
 func NewAccountIDFromStoreKey(val []byte) AccountID {
-	v := val[1:]
+	return NewAccountIDFromStoreByte(val[1:])
+}
+
+// NewAccountIDFromStoreByte creates a new accountID from store key
+func NewAccountIDFromStoreByte(v []byte) AccountID {
 	if len(v) != AccIDStoreKeyLen {
-		panic("unexpected AccountID store key length")
+		panic(errors.Errorf("unexpected AccountID store key length %x %d", v, len(v)))
 	}
 
 	if v[0] >= accountIDTypeIdxLen {
-		panic("unexpected AccountID prefix store key length")
+		panic(errors.Errorf("unexpected AccountID prefix store key length %d", v[0]))
 	}
 
 	return AccountID{

--- a/test/simapp/genesis.go
+++ b/test/simapp/genesis.go
@@ -64,7 +64,7 @@ func NewGenesisAccounts(rootAuth types.AccAddress, accounts ...SimGenesisAccount
 	}
 
 	for _, c := range coins2genesis {
-		createor, symbol, err := types.CoinAccountsFromDenom(c.Denom)
+		creator, symbol, err := types.CoinAccountsFromDenom(c.Denom)
 		if err != nil {
 			panic(errors.Wrapf(err, "coin symbol err %s", c.Denom))
 		}
@@ -75,7 +75,15 @@ func NewGenesisAccounts(rootAuth types.AccAddress, accounts ...SimGenesisAccount
 			max = types.NewInt(0)
 		}
 
-		res.coins = append(res.coins, assetTypes.NewGenesisCoin(createor, symbol, max, fmt.Sprintf("desc for %s", c.Denom)))
+		res.coins = append(res.coins, assetTypes.NewGenesisCoin(
+			&assetTypes.CoinStat{
+				Creator:      creator,
+				Symbol:       symbol,
+				CreateHeight: 1,
+				Supply:       types.NewCoin(c.Denom, types.NewInt(0)),
+				MaxSupply:    types.NewCoin(c.Denom, max),
+			},
+			[]byte(fmt.Sprintf("desc for %s", c.Denom))))
 	}
 
 	return res

--- a/x/account/exported/exported.go
+++ b/x/account/exported/exported.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/KuChainNetwork/kuchain/chain/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/crypto"
 )
 
 // AccountAuthKeeper is interface for trx auth and account state.
@@ -77,4 +78,25 @@ func (ga GenesisAccounts) Append(acc GenesisAccount) GenesisAccounts {
 type GenesisAccount interface {
 	Account
 	Validate() error
+}
+
+type GenesisAuth interface {
+	GetAddress() sdk.AccAddress
+	GetPubKey() crypto.PubKey
+	GetSequence() uint64
+	GetNumber() uint64
+}
+
+type GenesisAuths []GenesisAuth
+
+func (a GenesisAuths) Len() int {
+	return len(a)
+}
+
+func (a GenesisAuths) Less(i, j int) bool {
+	return a[i].GetNumber() < a[j].GetNumber()
+}
+
+func (a GenesisAuths) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
 }

--- a/x/account/genesis.go
+++ b/x/account/genesis.go
@@ -2,8 +2,10 @@ package account
 
 import (
 	"encoding/json"
+	"sort"
 
 	"github.com/KuChainNetwork/kuchain/x/account/exported"
+	"github.com/KuChainNetwork/kuchain/x/account/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -34,7 +36,18 @@ func ExportGenesis(ctx sdk.Context, ak Keeper) GenesisState {
 		return false
 	})
 
+	genAuths := exported.GenesisAuths(make([]exported.GenesisAuth, 0, 5120))
+	ak.IterateAuths(ctx, func(auth types.Auth) bool {
+		genAuths = append(genAuths, types.GenesisAuth{Auth: auth})
+		return false
+	})
+	sort.Stable(genAuths)
+
+	currNextAccountNumber := ak.QueryCurrNextAccountNumber(ctx)
+
 	return GenesisState{
-		Accounts: genAccounts,
+		Accounts:      genAccounts,
+		Auths:         genAuths,
+		AccountNumber: currNextAccountNumber,
 	}
 }

--- a/x/account/keeper/account.go
+++ b/x/account/keeper/account.go
@@ -100,7 +100,7 @@ func (ak AccountKeeper) IterateAuths(ctx sdk.Context, cb func(auth types.Auth) b
 		perfix := iterator.Key()[0]
 		address := chainTypes.AccAddress(iterator.Key()[1:])
 
-		ctx.Logger().Info("export auth",
+		ctx.Logger().Debug("export auth",
 			"perfix", perfix,
 			"auth", address,
 			"value", fmt.Sprintf("%X", iterator.Value()))

--- a/x/account/keeper/account.go
+++ b/x/account/keeper/account.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	"github.com/KuChainNetwork/kuchain/chain/store"
 	chainTypes "github.com/KuChainNetwork/kuchain/chain/types"
 	"github.com/KuChainNetwork/kuchain/x/account/exported"
@@ -79,6 +81,40 @@ func (ak AccountKeeper) IterateAccounts(ctx sdk.Context, cb func(account exporte
 		account := ak.decodeAccount(iterator.Value())
 
 		if cb(account) {
+			break
+		}
+	}
+}
+
+func (ak AccountKeeper) IterateAuths(ctx sdk.Context, cb func(auth types.Auth) bool) {
+	store := store.NewStore(ctx, ak.key)
+	iterator := sdk.KVStorePrefixIterator(store, types.AuthSeqStoreKeyPerfix)
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		var (
+			bz = iterator.Value()
+			an types.Auth
+		)
+
+		perfix := iterator.Key()[0]
+		address := chainTypes.AccAddress(iterator.Key()[1:])
+
+		ctx.Logger().Info("export auth",
+			"perfix", perfix,
+			"auth", address,
+			"value", fmt.Sprintf("%X", iterator.Value()))
+
+		if bz == nil {
+			an = types.NewAuth(address)
+			ak.initAuthData(ctx, &an)
+		} else {
+			if err := ak.cdc.UnmarshalBinaryBare(bz, &an); err != nil {
+				panic(sdkerrors.Wrap(err, "get auth data unmarshal"))
+			}
+		}
+
+		if cb(an) {
 			break
 		}
 	}

--- a/x/account/keeper/keeper.go
+++ b/x/account/keeper/keeper.go
@@ -46,6 +46,15 @@ func (ak AccountKeeper) Logger(ctx sdk.Context) log.Logger {
 // GetNextAccountNumber returns and increments the global account number counter.
 // If the global account number is not set, it initializes it with value 0.
 func (ak AccountKeeper) GetNextAccountNumber(ctx sdk.Context) uint64 {
+	accNumber := ak.QueryCurrNextAccountNumber(ctx)
+	bz := ak.cdc.MustMarshalBinaryLengthPrefixed(accNumber + 1)
+
+	store := store.NewStore(ctx, ak.key)
+	store.Set(types.GlobalAccountNumberKey, bz)
+	return accNumber
+}
+
+func (ak AccountKeeper) QueryCurrNextAccountNumber(ctx sdk.Context) uint64 {
 	var accNumber uint64
 	store := store.NewStore(ctx, ak.key)
 	bz := store.Get(types.GlobalAccountNumberKey)
@@ -58,9 +67,6 @@ func (ak AccountKeeper) GetNextAccountNumber(ctx sdk.Context) uint64 {
 			panic(err)
 		}
 	}
-
-	bz = ak.cdc.MustMarshalBinaryLengthPrefixed(accNumber + 1)
-	store.Set(types.GlobalAccountNumberKey, bz)
 	return accNumber
 }
 

--- a/x/account/types/codec.go
+++ b/x/account/types/codec.go
@@ -15,6 +15,7 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterInterface((*exported.Account)(nil), nil)
 	cdc.RegisterInterface((*exported.GenesisAccount)(nil), nil)
 	cdc.RegisterInterface((*exported.AuthAccountKeeper)(nil), nil)
+	cdc.RegisterInterface((*exported.GenesisAuth)(nil), nil)
 
 	cdc.RegisterConcrete(&MsgCreateAccountData{}, "account/createData", nil)
 	cdc.RegisterConcrete(&MsgCreateAccount{}, "account/createMsg", nil)
@@ -26,6 +27,7 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(&ModuleAccount{}, "kuchain/ModuleAccount", nil)
 
 	cdc.RegisterConcrete(&AuthAccounts{}, "account/authAccounts", nil)
+	cdc.RegisterConcrete(&GenesisAuth{}, "account/auth", nil)
 }
 
 // RegisterAccountTypeCodec registers an external account type defined in

--- a/x/account/types/genesis.go
+++ b/x/account/types/genesis.go
@@ -6,9 +6,15 @@ import (
 	"github.com/KuChainNetwork/kuchain/x/account/exported"
 )
 
+type GenesisAuth struct {
+	Auth
+}
+
 // GenesisState genesis state for account module
 type GenesisState struct {
-	Accounts exported.GenesisAccounts `json:"accounts"`
+	Accounts      exported.GenesisAccounts `json:"accounts"`
+	Auths         []exported.GenesisAuth   `json:"auths"`
+	AccountNumber uint64                   `json:"account_num"`
 }
 
 func (g GenesisState) ValidateGenesis(bz json.RawMessage) error {

--- a/x/asset/alias.go
+++ b/x/asset/alias.go
@@ -32,4 +32,5 @@ type (
 
 	GenesisState = types.GenesisState
 	GenesisAsset = types.GenesisAsset
+	GenesisCoin  = types.GenesisCoin
 )

--- a/x/asset/alias.go
+++ b/x/asset/alias.go
@@ -23,6 +23,7 @@ var (
 	NewGenesisState     = types.NewGenesisState
 	NewGenesisCoin      = types.NewGenesisCoin
 	NewGenesisAsset     = types.NewGenesisAsset
+	NewBaseGenesisLocks = types.NewBaseGenesisLocks
 	DefaultGenesisState = types.DefaultGenesisState
 )
 
@@ -33,4 +34,5 @@ type (
 	GenesisState = types.GenesisState
 	GenesisAsset = types.GenesisAsset
 	GenesisCoin  = types.GenesisCoin
+	GenesisLocks = types.GenesisLocks
 )

--- a/x/asset/client/gen/coin.go
+++ b/x/asset/client/gen/coin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/KuChainNetwork/kuchain/chain/types"
 	"github.com/KuChainNetwork/kuchain/x/asset"
+	assetTypes "github.com/KuChainNetwork/kuchain/x/asset/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/spf13/cobra"
@@ -62,7 +63,14 @@ func addCoin(cdc *codec.Codec, state *asset.GenesisState, creator, symbol types.
 		}
 	}
 
-	c := asset.NewGenesisCoin(creator, symbol, maxSupply.Amount, desc)
+	c := asset.NewGenesisCoin(&assetTypes.CoinStat{
+		Creator:      creator,
+		Symbol:       symbol,
+		CreateHeight: 1,
+		Supply:       types.NewCoin(maxSupply.Denom, types.NewInt(0)),
+		MaxSupply:    maxSupply,
+	}, []byte(desc))
+
 	if err := c.Validate(); err != nil {
 		return err
 	}

--- a/x/asset/genesis.go
+++ b/x/asset/genesis.go
@@ -52,9 +52,16 @@ func ExportGenesis(ctx sdk.Context, ak Keeper) GenesisState {
 		return false
 	})
 
+	coinpowers := make([]GenesisAsset, 0, 5120)
+	ak.IterateAllCoinPowers(ctx, func(add types.AccountID, c types.Coins) bool {
+		coinpowers = append(coinpowers, assetTypes.NewGenesisAsset(add, c...))
+		return false
+	})
+
 	res := GenesisState{
-		GenesisCoins:  coinsStats,
-		GenesisAssets: assets,
+		GenesisCoins:      coinsStats,
+		GenesisAssets:     assets,
+		GenesisCoinPowers: coinpowers,
 	}
 
 	return res

--- a/x/asset/genesis.go
+++ b/x/asset/genesis.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/KuChainNetwork/kuchain/chain/types"
+	assetTypes "github.com/KuChainNetwork/kuchain/x/asset/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -39,7 +40,24 @@ func InitGenesis(ctx sdk.Context, ak Keeper, bz json.RawMessage) {
 
 // ExportGenesis returns a GenesisState for a given context and keeper
 func ExportGenesis(ctx sdk.Context, ak Keeper) GenesisState {
-	return GenesisState{}
+	coinsStats := make([]GenesisCoin, 0, 512)
+	ak.IterateAllAssets(ctx, func(stat *assetTypes.CoinStat, desc []byte) bool {
+		coinsStats = append(coinsStats, assetTypes.NewGenesisCoin(stat, desc))
+		return false
+	})
+
+	assets := make([]GenesisAsset, 0, 5120)
+	ak.IterateAllCoins(ctx, func(add types.AccountID, c types.Coins) bool {
+		assets = append(assets, assetTypes.NewGenesisAsset(add, c...))
+		return false
+	})
+
+	res := GenesisState{
+		GenesisCoins:  coinsStats,
+		GenesisAssets: assets,
+	}
+
+	return res
 }
 
 // GenesisBalancesIterator implements genesis account iteration.

--- a/x/asset/genesis.go
+++ b/x/asset/genesis.go
@@ -47,14 +47,26 @@ func ExportGenesis(ctx sdk.Context, ak Keeper) GenesisState {
 	})
 
 	assets := make([]GenesisAsset, 0, 5120)
-	ak.IterateAllCoins(ctx, func(add types.AccountID, c types.Coins) bool {
-		assets = append(assets, assetTypes.NewGenesisAsset(add, c...))
+	ak.IterateAllCoins(ctx, func(id types.AccountID, c types.Coins) bool {
+		assets = append(assets, assetTypes.NewGenesisAsset(id, c...))
 		return false
 	})
 
 	coinpowers := make([]GenesisAsset, 0, 5120)
-	ak.IterateAllCoinPowers(ctx, func(add types.AccountID, c types.Coins) bool {
-		coinpowers = append(coinpowers, assetTypes.NewGenesisAsset(add, c...))
+	ak.IterateAllCoinPowers(ctx, func(id types.AccountID, c types.Coins) bool {
+		coinpowers = append(coinpowers, assetTypes.NewGenesisAsset(id, c...))
+		return false
+	})
+
+	locks := make([]GenesisLocks, 0, 512)
+	ak.IterateCoinLockedStats(ctx, func(id types.AccountID, lock []assetTypes.LockedCoins) bool {
+		locks = append(locks, NewBaseGenesisLocks(id, lock))
+		return false
+	})
+
+	lockAssets := make([]GenesisAsset, 0, 512)
+	ak.IterateCoinLockeds(ctx, func(id types.AccountID, c types.Coins) bool {
+		lockAssets = append(lockAssets, assetTypes.NewGenesisAsset(id, c...))
 		return false
 	})
 
@@ -62,6 +74,8 @@ func ExportGenesis(ctx sdk.Context, ak Keeper) GenesisState {
 		GenesisCoins:      coinsStats,
 		GenesisAssets:     assets,
 		GenesisCoinPowers: coinpowers,
+		GenesisLocks:      locks,
+		GenesisLockAssets: lockAssets,
 	}
 
 	return res

--- a/x/asset/genesis.go
+++ b/x/asset/genesis.go
@@ -58,6 +58,7 @@ func ExportGenesis(ctx sdk.Context, ak Keeper) GenesisState {
 		return false
 	})
 
+	// FIXME: Change Locked Block height to zero
 	locks := make([]GenesisLocks, 0, 512)
 	ak.IterateCoinLockedStats(ctx, func(id types.AccountID, lock []assetTypes.LockedCoins) bool {
 		locks = append(locks, NewBaseGenesisLocks(id, lock))

--- a/x/asset/keeper/keeper_view.go
+++ b/x/asset/keeper/keeper_view.go
@@ -1,12 +1,10 @@
 package keeper
 
 import (
-	"errors"
-
 	"github.com/KuChainNetwork/kuchain/chain/store"
 	"github.com/KuChainNetwork/kuchain/x/asset/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/pkg/errors"
 )
 
 // GetCoins get coins by account id
@@ -18,7 +16,7 @@ func (a AssetKeeper) GetCoins(ctx sdk.Context, account types.AccountID) (types.C
 func (a AssetKeeper) GetCoin(ctx sdk.Context, account types.AccountID, creator, symbol types.Name) (types.Coin, error) {
 	coins, err := a.getCoins(ctx, account)
 	if err != nil {
-		return types.Coin{}, sdkerrors.Wrapf(err, "get coin %s %s-%s", account, creator, symbol)
+		return types.Coin{}, errors.Wrapf(err, "get coin %s %s-%s", account, creator, symbol)
 	}
 	denomd := types.CoinDenom(creator, symbol)
 
@@ -39,7 +37,7 @@ func (a AssetKeeper) GetCoinPowers(ctx sdk.Context, account types.AccountID) typ
 func (a AssetKeeper) GetCoinPower(ctx sdk.Context, account types.AccountID, creator, symbol types.Name) (types.Coin, error) {
 	coins, err := a.getCoinsPower(ctx, account)
 	if err != nil {
-		return types.Coin{}, sdkerrors.Wrapf(err, "get coin power %s %s-%s", account, creator, symbol)
+		return types.Coin{}, errors.Wrapf(err, "get coin power %s %s-%s", account, creator, symbol)
 	}
 	denomd := types.CoinDenom(creator, symbol)
 
@@ -91,9 +89,35 @@ func (a AssetKeeper) GetCoinsTotalSupply(ctx sdk.Context) types.Coins {
 func (a AssetKeeper) GetCoinTotalSupply(ctx sdk.Context, creator, symbol types.Name) types.Coin {
 	stat, err := a.getStat(ctx, creator, symbol)
 	if err != nil {
-		panic(sdkerrors.Wrapf(err, "get coin total supply %s/%s", creator, symbol))
+		panic(errors.Wrapf(err, "get coin total supply %s/%s", creator, symbol))
 	}
 	return stat.Supply
+}
+
+func (a AssetKeeper) IterateAllAssets(ctx sdk.Context, cb func(stat *types.CoinStat, desc []byte) (stop bool)) {
+	store := store.NewStore(ctx, a.key)
+	iterator := sdk.KVStorePrefixIterator(store, types.GetKeyPrefix(types.CoinStatStoreKeyPrefix))
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		var (
+			cs types.CoinStat
+		)
+
+		if err := a.cdc.UnmarshalBinaryBare(iterator.Value(), &cs); err != nil {
+			panic(errors.New("unmarshal coins in store error"))
+		}
+
+		// find desc
+		desc, err := a.GetCoinDesc(ctx, cs.Creator, cs.Symbol)
+		if err != nil {
+			panic(errors.Wrapf(err, "get coin desc %s %s err", cs.Creator, cs.Symbol))
+		}
+
+		if cb(&cs, desc.Description) {
+			break
+		}
+	}
 }
 
 // IterateAllCoins iterate all account 's coins

--- a/x/asset/keeper/keeper_view.go
+++ b/x/asset/keeper/keeper_view.go
@@ -154,7 +154,7 @@ func (a AssetKeeper) IterateAllCoinPowers(ctx sdk.Context, cb func(address types
 			coins types.Coins
 		)
 
-		id := types.AccountIDFromCoinStoreKey(iterator.Key())
+		id := types.AccountIDFromCoinPowerStoreKey(iterator.Key())
 
 		if err := a.cdc.UnmarshalBinaryBare(iterator.Value(), &coins); err != nil {
 			panic(errors.New("unmarshal coins in store error"))

--- a/x/asset/types/codec.go
+++ b/x/asset/types/codec.go
@@ -11,9 +11,12 @@ var ModuleCdc = codec.New()
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterInterface((*GenesisAsset)(nil), nil)
 	cdc.RegisterInterface((*GenesisCoin)(nil), nil)
+	cdc.RegisterInterface((*GenesisLocks)(nil), nil)
+
 	cdc.RegisterConcrete(&GenesisState{}, "asset/genesisState", nil)
 	cdc.RegisterConcrete(&BaseGensisAssetCoin{}, "asset/genesisCoin", nil)
 	cdc.RegisterConcrete(&BaseGenesisAsset{}, "asset/genesisAsset", nil)
+	cdc.RegisterConcrete(&BaseGenesisLocks{}, "asset/genesisLock", nil)
 
 	cdc.RegisterConcrete(&KuMsg{}, "kuchain/msg", nil)
 

--- a/x/asset/types/genesis.go
+++ b/x/asset/types/genesis.go
@@ -8,11 +8,36 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+type GenesisLocks interface {
+	GetID() AccountID
+	LockedByHeight() []LockedCoins
+}
+
+type BaseGenesisLocks struct {
+	ID      AccountID     `json:"id" yaml:"id"`
+	Lockeds []LockedCoins `json:"lockeds" yaml:"lockeds"`
+}
+
+func NewBaseGenesisLocks(id AccountID, lockeds []LockedCoins) BaseGenesisLocks {
+	return BaseGenesisLocks{
+		ID:      id,
+		Lockeds: lockeds,
+	}
+}
+
+func (g BaseGenesisLocks) GetID() AccountID { return g.ID }
+
+func (g BaseGenesisLocks) LockedByHeight() []LockedCoins {
+	return g.Lockeds
+}
+
 // GenesisState is the bank state that must be provided at genesis.
 type GenesisState struct {
 	GenesisAssets     []GenesisAsset `json:"genesisAssets"`
 	GenesisCoins      []GenesisCoin  `json:"genesisCoins"`
 	GenesisCoinPowers []GenesisAsset `json:"genesisCoinPowers"`
+	GenesisLocks      []GenesisLocks `json:"genesisLocks"`
+	GenesisLockAssets []GenesisAsset `json:"genesisLockAssets"`
 }
 
 // NewGenesisState creates a new genesis state.
@@ -21,6 +46,8 @@ func NewGenesisState() GenesisState {
 		GenesisAssets:     make([]GenesisAsset, 0),
 		GenesisCoins:      make([]GenesisCoin, 0),
 		GenesisCoinPowers: make([]GenesisAsset, 0),
+		GenesisLocks:      make([]GenesisLocks, 0),
+		GenesisLockAssets: make([]GenesisAsset, 0),
 	}
 }
 

--- a/x/asset/types/genesis.go
+++ b/x/asset/types/genesis.go
@@ -37,6 +37,8 @@ func (g GenesisState) ValidateGenesis(bz json.RawMessage) error {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", ModuleName, err)
 	}
 
+	// TODO: check genesis
+
 	return nil
 }
 
@@ -81,18 +83,14 @@ func (g BaseGenesisAsset) GetCoins() Coins { return g.Coins }
 
 // GensisAssetCoin
 type BaseGensisAssetCoin struct {
-	Creator     Name   `json:"creator"`
-	Symbol      Name   `json:"symbol"`
-	MaxSupply   Coin   `json:"maxSupply"`
-	Description string `json:"description"`
+	Stat        CoinStat `json:"stat"`
+	Description string   `json:"description"`
 }
 
-func NewGenesisCoin(creator, symbol Name, maxSupplyAmount Int, description string) BaseGensisAssetCoin {
+func NewGenesisCoin(stat *CoinStat, description []byte) BaseGensisAssetCoin {
 	return BaseGensisAssetCoin{
-		Creator:     creator,
-		Symbol:      symbol,
-		MaxSupply:   NewCoin(CoinDenom(creator, symbol), maxSupplyAmount),
-		Description: description,
+		Stat:        *stat,
+		Description: string(description),
 	}
 }
 
@@ -102,9 +100,9 @@ func (g BaseGensisAssetCoin) Validate() error {
 		return fmt.Errorf("genesis coin description too length")
 	}
 
-	denom := CoinDenom(g.Creator, g.Symbol)
+	denom := CoinDenom(g.Stat.Creator, g.Stat.Symbol)
 
-	if denom != g.MaxSupply.Denom {
+	if denom != g.Stat.MaxSupply.Denom {
 		return fmt.Errorf("genesis max supply coin denom error")
 	}
 
@@ -116,13 +114,13 @@ func (g BaseGensisAssetCoin) Validate() error {
 }
 
 // GetCreator imp GenesisCoin
-func (g BaseGensisAssetCoin) GetCreator() Name { return g.Creator }
+func (g BaseGensisAssetCoin) GetCreator() Name { return g.Stat.Creator }
 
 // GetSymbol imp GenesisCoin
-func (g BaseGensisAssetCoin) GetSymbol() Name { return g.Symbol }
+func (g BaseGensisAssetCoin) GetSymbol() Name { return g.Stat.Symbol }
 
 // GetMaxSupply imp GenesisCoin
-func (g BaseGensisAssetCoin) GetMaxSupply() Coin { return g.MaxSupply }
+func (g BaseGensisAssetCoin) GetMaxSupply() Coin { return g.Stat.MaxSupply }
 
 // GetDescription imp GenesisCoin
 func (g BaseGensisAssetCoin) GetDescription() string { return g.Description }

--- a/x/asset/types/genesis.go
+++ b/x/asset/types/genesis.go
@@ -10,15 +10,17 @@ import (
 
 // GenesisState is the bank state that must be provided at genesis.
 type GenesisState struct {
-	GenesisAssets []GenesisAsset `json:"genesisAssets"`
-	GenesisCoins  []GenesisCoin  `json:"genesisCoins"`
+	GenesisAssets     []GenesisAsset `json:"genesisAssets"`
+	GenesisCoins      []GenesisCoin  `json:"genesisCoins"`
+	GenesisCoinPowers []GenesisAsset `json:"genesisCoinPowers"`
 }
 
 // NewGenesisState creates a new genesis state.
 func NewGenesisState() GenesisState {
 	return GenesisState{
-		GenesisAssets: make([]GenesisAsset, 0),
-		GenesisCoins:  make([]GenesisCoin, 0),
+		GenesisAssets:     make([]GenesisAsset, 0),
+		GenesisCoins:      make([]GenesisCoin, 0),
+		GenesisCoinPowers: make([]GenesisAsset, 0),
 	}
 }
 

--- a/x/distribution/genesis.go
+++ b/x/distribution/genesis.go
@@ -137,5 +137,8 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) types.GenesisState {
 		},
 	)
 
-	return types.NewGenesisState(params, feePool, dwi, pp, outstanding, acc, his, cur, dels, slashes)
+	return types.NewGenesisState(
+		params, feePool, dwi, pp,
+		outstanding, acc, his, cur, dels, slashes,
+		keeper.QueryStartNotDistributionTimePoint(ctx))
 }

--- a/x/distribution/keeper/keeper.go
+++ b/x/distribution/keeper/keeper.go
@@ -211,6 +211,17 @@ func (k *Keeper) GetStartNotDistributionTimePoint(ctx sdk.Context) {
 		"time", k.startNotDistriTimePoint.Nanosecond())
 }
 
+func (k Keeper) QueryStartNotDistributionTimePoint(ctx sdk.Context) time.Time {
+	var res time.Time
+
+	store := store.NewStore(ctx, k.storeKey)
+	bz := store.Get([]byte(key))
+
+	k.cdc.UnmarshalJSON(bz, &res)
+
+	return res
+}
+
 func (k Keeper) CanDistribution(ctx sdk.Context) (bool, time.Time) {
 	if k.startNotDistriTimePoint.Nanosecond() <= 0 {
 		return true, k.startNotDistriTimePoint

--- a/x/distribution/types/alias.go
+++ b/x/distribution/types/alias.go
@@ -26,8 +26,9 @@ type (
 )
 
 var (
-	NewAccountIDFromStoreKey = types.NewAccountIDFromStoreKey
-	MustName                 = types.MustName
+	NewAccountIDFromStoreKey  = types.NewAccountIDFromStoreKey
+	NewAccountIDFromStoreByte = types.NewAccountIDFromStoreByte
+	MustName                  = types.MustName
 )
 
 const (

--- a/x/distribution/types/genesis.go
+++ b/x/distribution/types/genesis.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -66,12 +67,14 @@ type GenesisState struct {
 	ValidatorCurrentRewards         []ValidatorCurrentRewardsRecord        `json:"validator_current_rewards" yaml:"validator_current_rewards"`
 	DelegatorStartingInfos          []DelegatorStartingInfoRecord          `json:"delegator_starting_infos" yaml:"delegator_starting_infos"`
 	ValidatorSlashEvents            []ValidatorSlashEventRecord            `json:"validator_slash_events" yaml:"validator_slash_events"`
+	NotDistributionTimePoint        time.Time                              `json:"not_distribution_time_point" yaml:"not_distribution_time_point"`
 }
 
 func NewGenesisState(
 	params Params, fp FeePool, dwis []DelegatorWithdrawInfo, pp sdk.ConsAddress, r []ValidatorOutstandingRewardsRecord,
 	acc []ValidatorAccumulatedCommissionRecord, historical []ValidatorHistoricalRewardsRecord,
 	cur []ValidatorCurrentRewardsRecord, dels []DelegatorStartingInfoRecord, slashes []ValidatorSlashEventRecord,
+	notDistributionTimePoint time.Time,
 ) GenesisState {
 
 	return GenesisState{
@@ -85,6 +88,7 @@ func NewGenesisState(
 		ValidatorCurrentRewards:         cur,
 		DelegatorStartingInfos:          dels,
 		ValidatorSlashEvents:            slashes,
+		NotDistributionTimePoint:        notDistributionTimePoint,
 	}
 }
 

--- a/x/distribution/types/keys.go
+++ b/x/distribution/types/keys.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 
 	"github.com/KuChainNetwork/kuchain/chain/types"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -75,10 +76,14 @@ func GetDelegatorWithdrawInfoAddressUseAccountId(key []byte) AccountID {
 
 // gets the addresses from a delegator starting info key
 func GetDelegatorStartingInfoAddresses(key []byte) (valAddr AccountID, delAddr AccountID) {
-	addr := key[:1+AccIDStoreKeyLen]
-	valAddr = NewAccountIDFromStoreKey(addr)
-	addr = key[1+AccIDStoreKeyLen:]
-	delAddr = NewAccountIDFromStoreKey(addr)
+	if key[0] != DelegatorStartingInfoPrefix[0] {
+		panic(errors.Errorf("key prefix unknown %d", key[0]))
+	}
+
+	valAddr = NewAccountIDFromStoreKey(key[:1+AccIDStoreKeyLen])
+	add := make([]byte, AccIDStoreKeyLen)
+	copy(add, key[1+AccIDStoreKeyLen:])
+	delAddr = NewAccountIDFromStoreByte(add)
 	return
 }
 

--- a/x/gov/genesis.go
+++ b/x/gov/genesis.go
@@ -63,6 +63,12 @@ func ExportGenesis(ctx sdk.Context, k Keeper) GenesisState {
 		proposalsVotes = append(proposalsVotes, votes...)
 	}
 
+	pvs := make([]types.PunishValidator, 0, 64)
+	k.IterateAllPunishValidators(ctx, func(v types.PunishValidator) bool {
+		pvs = append(pvs, v)
+		return false
+	})
+
 	return GenesisState{
 		StartingProposalID: startingProposalID,
 		Deposits:           proposalsDeposits,
@@ -71,5 +77,6 @@ func ExportGenesis(ctx sdk.Context, k Keeper) GenesisState {
 		DepositParams:      depositParams,
 		VotingParams:       votingParams,
 		TallyParams:        tallyParams,
+		PunishValidators:   pvs,
 	}
 }

--- a/x/gov/simulation/genesis.go
+++ b/x/gov/simulation/genesis.go
@@ -117,6 +117,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 		types.NewDepositParams(minDeposit, depositPeriod),
 		types.NewVotingParams(votingPeriod),
 		types.NewTallyParams(quorum, threshold, veto, emergency, punishPeriod, quorum),
+		types.DefaultPunishValidators(),
 	)
 
 	fmt.Printf("Selected randomly generated governance parameters:\n%s\n", codec.MustMarshalJSONIndent(simState.Cdc, govGenesis))

--- a/x/gov/types/genesis.go
+++ b/x/gov/types/genesis.go
@@ -9,22 +9,24 @@ import (
 
 // GenesisState - all staking state that must be provided at genesis
 type GenesisState struct {
-	StartingProposalID uint64        `json:"starting_proposal_id" yaml:"starting_proposal_id"`
-	Deposits           Deposits      `json:"deposits" yaml:"deposits"`
-	Votes              Votes         `json:"votes" yaml:"votes"`
-	Proposals          Proposals     `json:"proposals" yaml:"proposals"`
-	DepositParams      DepositParams `json:"deposit_params" yaml:"deposit_params"`
-	VotingParams       VotingParams  `json:"voting_params" yaml:"voting_params"`
-	TallyParams        TallyParams   `json:"tally_params" yaml:"tally_params"`
+	StartingProposalID uint64            `json:"starting_proposal_id" yaml:"starting_proposal_id"`
+	Deposits           Deposits          `json:"deposits" yaml:"deposits"`
+	Votes              Votes             `json:"votes" yaml:"votes"`
+	Proposals          Proposals         `json:"proposals" yaml:"proposals"`
+	DepositParams      DepositParams     `json:"deposit_params" yaml:"deposit_params"`
+	VotingParams       VotingParams      `json:"voting_params" yaml:"voting_params"`
+	TallyParams        TallyParams       `json:"tally_params" yaml:"tally_params"`
+	PunishValidators   []PunishValidator `json:"punish_validators" yaml:"punish_validators"`
 }
 
 // NewGenesisState creates a new genesis state for the governance module
-func NewGenesisState(startingProposalID uint64, dp DepositParams, vp VotingParams, tp TallyParams) GenesisState {
+func NewGenesisState(startingProposalID uint64, dp DepositParams, vp VotingParams, tp TallyParams, pvs []PunishValidator) GenesisState {
 	return GenesisState{
 		StartingProposalID: startingProposalID,
 		DepositParams:      dp,
 		VotingParams:       vp,
 		TallyParams:        tp,
+		PunishValidators:   pvs,
 	}
 }
 
@@ -35,6 +37,7 @@ func DefaultGenesisState() GenesisState {
 		DefaultDepositParams(),
 		DefaultVotingParams(),
 		DefaultTallyParams(),
+		DefaultPunishValidators(),
 	)
 }
 

--- a/x/gov/types/params.go
+++ b/x/gov/types/params.go
@@ -120,6 +120,10 @@ func DefaultTallyParams() TallyParams {
 	return NewTallyParams(DefaultQuorum, DefaultThreshold, DefaultVeto, DefaultEmergengcy, DefaultPunishPeriod, DefaultSlashFraction)
 }
 
+func DefaultPunishValidators() []PunishValidator {
+	return make([]PunishValidator, 0)
+}
+
 // Equal checks equality of TallyParams
 func (tp TallyParams) Equal(other TallyParams) bool {
 	return tp.Quorum.Equal(other.Quorum) && tp.Threshold.Equal(other.Threshold) && tp.Veto.Equal(other.Veto)

--- a/x/slashing/keeper/signing_info.go
+++ b/x/slashing/keeper/signing_info.go
@@ -3,8 +3,6 @@ package keeper
 import (
 	"time"
 
-	gogotypes "github.com/gogo/protobuf/types"
-
 	"github.com/KuChainNetwork/kuchain/chain/store"
 	"github.com/KuChainNetwork/kuchain/x/slashing/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -77,14 +75,14 @@ func (k Keeper) IterateValidatorMissedBlockBitArray(ctx sdk.Context,
 	index := int64(0)
 	// Array may be sparse
 	for ; index < k.SignedBlocksWindow(ctx); index++ {
-		var missed gogotypes.BoolValue
+		var missed bool
 		bz := store.Get(types.GetValidatorMissedBlockBitArrayKey(address, index))
 		if bz == nil {
 			continue
 		}
 
-		k.cdc.MustUnmarshalBinaryBare(bz, &missed)
-		if handler(index, missed.Value) {
+		k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &missed)
+		if handler(index, missed) {
 			break
 		}
 	}

--- a/x/supply/genesis.go
+++ b/x/supply/genesis.go
@@ -13,6 +13,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, bk types.BankKeeper, data Genes
 
 // ExportGenesis returns a GenesisState for a given context and keeper.
 func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
+	// useless
 	return NewGenesisState(keeper.GetSupply(ctx).GetTotal())
 }
 


### PR DESCRIPTION
## Summary

Fix Support For export genesis status for kratos.

## Introduction

After dex developed, the kratos testnet will into the 2-step blockchain by genesis from 1-step.

So we fix some support for export genesis status in release branch.

## Modifys

- add genesis export for asset, account module
- fix genesis missings for other modules

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes