### PR TITLE
API for AccountID type

### DIFF
--- a/test/simapp/export.go
+++ b/test/simapp/export.go
@@ -66,7 +66,7 @@ func (app *SimApp) prepForZeroHeightGenesis(ctx sdk.Context, jailWhiteList []str
 
 	// withdraw all validator commission
 	app.stakingKeeper.IterateValidators(ctx, func(_ int64, val exported.ValidatorI) (stop bool) {
-		_, _ = app.distrKeeper.WithdrawValidatorCommission(ctx, val.GetOperatorAccountID())
+		_, _ = app.distrKeeper.WithdrawValidatorCommission(ctx, val.GetOperator())
 		return false
 	})
 
@@ -90,12 +90,12 @@ func (app *SimApp) prepForZeroHeightGenesis(ctx sdk.Context, jailWhiteList []str
 	app.stakingKeeper.IterateValidators(ctx, func(_ int64, val exported.ValidatorI) (stop bool) {
 
 		// donate any unwithdrawn outstanding reward fraction tokens to the community pool
-		scraps := app.distrKeeper.GetValidatorOutstandingRewards(ctx, val.GetOperatorAccountID())
+		scraps := app.distrKeeper.GetValidatorOutstandingRewards(ctx, val.GetOperator())
 		feePool := app.distrKeeper.GetFeePool(ctx)
 		feePool.CommunityPool = feePool.CommunityPool.Add(scraps.Rewards...)
 		app.distrKeeper.SetFeePool(ctx, feePool)
 
-		app.distrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperatorAccountID())
+		app.distrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
 		return false
 	})
 

--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -57,7 +57,7 @@ func (k Keeper) AllocateTokens(
 			sdk.NewEvent(
 				types.EventTypeProposerReward,
 				sdk.NewAttribute(sdk.AttributeKeyAmount, proposerReward.String()),
-				sdk.NewAttribute(types.AttributeKeyValidator, proposerValidator.GetOperatorAccountID().String()),
+				sdk.NewAttribute(types.AttributeKeyValidator, proposerValidator.GetOperator().String()),
 			),
 		)
 
@@ -111,33 +111,33 @@ func (k Keeper) AllocateTokensToValidator(ctx sdk.Context, val types.StakingExpo
 		sdk.NewEvent(
 			types.EventTypeCommission,
 			sdk.NewAttribute(sdk.AttributeKeyAmount, commission.String()),
-			sdk.NewAttribute(types.AttributeKeyValidator, val.GetOperatorAccountID().String()),
+			sdk.NewAttribute(types.AttributeKeyValidator, val.GetOperator().String()),
 		),
 	)
-	currentCommission := k.GetValidatorAccumulatedCommission(ctx, val.GetOperatorAccountID())
+	currentCommission := k.GetValidatorAccumulatedCommission(ctx, val.GetOperator())
 	currentCommission.Commission = currentCommission.Commission.Add(commission...)
-	k.SetValidatorAccumulatedCommission(ctx, val.GetOperatorAccountID(), currentCommission)
+	k.SetValidatorAccumulatedCommission(ctx, val.GetOperator(), currentCommission)
 	ctx.Logger().Debug("AllocateTokensToValidator",
-		"operator", val.GetOperatorAccountID(),
+		"operator", val.GetOperator(),
 		"currentCommission", currentCommission)
 
 	// update current rewards
-	currentRewards := k.GetValidatorCurrentRewards(ctx, val.GetOperatorAccountID())
+	currentRewards := k.GetValidatorCurrentRewards(ctx, val.GetOperator())
 	currentRewards.Rewards = currentRewards.Rewards.Add(shared...)
-	k.SetValidatorCurrentRewards(ctx, val.GetOperatorAccountID(), currentRewards)
+	k.SetValidatorCurrentRewards(ctx, val.GetOperator(), currentRewards)
 
 	// update outstanding rewards
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeRewards,
 			sdk.NewAttribute(sdk.AttributeKeyAmount, tokens.String()),
-			sdk.NewAttribute(types.AttributeKeyValidator, val.GetOperatorAccountID().String()),
+			sdk.NewAttribute(types.AttributeKeyValidator, val.GetOperator().String()),
 		),
 	)
-	outstanding := k.GetValidatorOutstandingRewards(ctx, val.GetOperatorAccountID())
+	outstanding := k.GetValidatorOutstandingRewards(ctx, val.GetOperator())
 	outstanding.Rewards = outstanding.Rewards.Add(tokens...)
 	ctx.Logger().Debug("AllocateTokensToValidator",
-		"operator", val.GetOperatorAccountID(),
+		"operator", val.GetOperator(),
 		"outstanding", outstanding)
-	k.SetValidatorOutstandingRewards(ctx, val.GetOperatorAccountID(), outstanding)
+	k.SetValidatorOutstandingRewards(ctx, val.GetOperator(), outstanding)
 }

--- a/x/distribution/keeper/allocation_test.go
+++ b/x/distribution/keeper/allocation_test.go
@@ -4,8 +4,9 @@ import (
 	"github.com/KuChainNetwork/kuchain/chain/constants"
 	chainType "github.com/KuChainNetwork/kuchain/chain/types"
 
-	abci "github.com/tendermint/tendermint/abci/types"
 	"testing"
+
+	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/stretchr/testify/require"
 
@@ -60,11 +61,11 @@ func TestAllocateTokensToValidatorWithCommission(t *testing.T) {
 		{Denom: constants.DefaultBondDenom, Amount: sdk.NewDec(5)},
 	}
 
-	ru := k.GetValidatorAccumulatedCommission(ctx, val.GetOperatorAccountID())
+	ru := k.GetValidatorAccumulatedCommission(ctx, val.GetOperator())
 	require.Equal(t, expected, ru.Commission)
 
 	// check current rewards
-	require.Equal(t, expected, k.GetValidatorCurrentRewards(ctx, val.GetOperatorAccountID()).Rewards)
+	require.Equal(t, expected, k.GetValidatorCurrentRewards(ctx, val.GetOperator()).Rewards)
 }
 
 func TestAllocateTokensToManyValidators(t *testing.T) {

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -39,8 +39,8 @@ func (k Keeper) calculateDelegationRewardsBetween(ctx sdk.Context, val types.Val
 	}
 
 	// return staking * (ending - starting)
-	starting := k.GetValidatorHistoricalRewards(ctx, val.GetOperatorAccountID(), startingPeriod)
-	ending := k.GetValidatorHistoricalRewards(ctx, val.GetOperatorAccountID(), endingPeriod)
+	starting := k.GetValidatorHistoricalRewards(ctx, val.GetOperator(), startingPeriod)
+	ending := k.GetValidatorHistoricalRewards(ctx, val.GetOperator(), endingPeriod)
 	difference := ending.CumulativeRewardRatio.Sub(starting.CumulativeRewardRatio)
 	if difference.IsAnyNegative() {
 		panic("negative rewards should not be possible")
@@ -162,7 +162,7 @@ func (k Keeper) withdrawDelegationRewards(ctx sdk.Context, val types.ValidatorI,
 		logger := k.Logger(ctx)
 		logger.Info(fmt.Sprintf("missing rewards rounding error, delegator %v"+
 			"withdrawing rewards from validator %v, should have received %v, got %v",
-			val.GetOperatorAccountID(), del.GetDelegator(), rewardsRaw, rewards))
+			val.GetOperator(), del.GetDelegator(), rewardsRaw, rewards))
 	}
 
 	// truncate coins, return remainder to community pool

--- a/x/distribution/keeper/invariants.go
+++ b/x/distribution/keeper/invariants.go
@@ -77,10 +77,10 @@ func CanWithdrawInvariant(k Keeper) sdk.Invariant {
 
 		// iterate over all validators
 		k.stakingKeeper.IterateValidators(ctx, func(_ int64, val types.StakingExportedValidatorI) (stop bool) {
-			valID := val.GetOperatorAccountID()
+			valID := val.GetOperator()
 			_, _ = k.WithdrawValidatorCommission(ctx, valID)
 
-			delegations, ok := valDelegations[val.GetOperatorAccountID().String()]
+			delegations, ok := valDelegations[val.GetOperator().String()]
 			if ok {
 				for _, del := range delegations {
 					if _, err := k.WithdrawDelegationRewards(ctx, del, valID); err != nil {
@@ -89,7 +89,7 @@ func CanWithdrawInvariant(k Keeper) sdk.Invariant {
 				}
 			}
 
-			remaining = k.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperatorAccountID())
+			remaining = k.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperator())
 			if len(remaining) > 0 && remaining[0].Amount.IsNegative() {
 				return true
 			}

--- a/x/distribution/simulation/operations.go
+++ b/x/distribution/simulation/operations.go
@@ -151,7 +151,7 @@ func SimulateMsgWithdrawDelegatorReward(ak types.AccountKeeperAccountID, bk type
 			return types.SimulationNoOpMsg(types.ModuleName), nil, err
 		}
 
-		valId := validator.GetOperatorAccountID()
+		valId := validator.GetOperator()
 		msg := types.NewMsgWithdrawDelegatorReward(account.GetAuth(), simAccountId, valId)
 
 		tx := helpers.GenTx(
@@ -184,14 +184,14 @@ func SimulateMsgWithdrawValidatorCommission(ak types.AccountKeeperAccountID, bk 
 			return types.SimulationNoOpMsg(types.ModuleName), nil, nil
 		}
 
-		commission := k.GetValidatorAccumulatedCommission(ctx, validator.GetOperatorAccountID())
+		commission := k.GetValidatorAccumulatedCommission(ctx, validator.GetOperator())
 		if commission.Commission.IsZero() {
 			return types.SimulationNoOpMsg(types.ModuleName), nil, nil
 		}
 
-		simAccount, found := types.SimulationFindAccount(accs, sdk.AccAddress(validator.GetOperator()))
+		simAccount, found := types.SimulationFindAccount(accs, sdk.AccAddress(validator.GetOperatorAddress()))
 		if !found {
-			return types.SimulationNoOpMsg(types.ModuleName), nil, fmt.Errorf("validator %s not found", validator.GetOperator())
+			return types.SimulationNoOpMsg(types.ModuleName), nil, fmt.Errorf("validator %s not found", validator.GetOperatorAddress())
 		}
 
 		simAccountId := chainTypes.NewAccountIDFromAccAdd(simAccount.Address)
@@ -205,7 +205,7 @@ func SimulateMsgWithdrawValidatorCommission(ak types.AccountKeeperAccountID, bk 
 			return types.SimulationNoOpMsg(types.ModuleName), nil, err
 		}
 
-		valId, _ := chainTypes.NewAccountIDFromStr(string(validator.GetOperator())) //bugs, staking interface
+		valId, _ := chainTypes.NewAccountIDFromStr(string(validator.GetOperatorAddress())) //bugs, staking interface
 		msg := types.NewMsgWithdrawValidatorCommission(account.GetAuth(), valId)
 
 		tx := helpers.GenTx(

--- a/x/gov/keeper/tally.go
+++ b/x/gov/keeper/tally.go
@@ -26,8 +26,8 @@ func (keeper Keeper) Tally(
 	currValidators := make(map[string]types.ValidatorGovInfo)
 	// fetch all the bonded validators, insert them into currValidators
 	keeper.sk.IterateBondedValidatorsByPower(ctx, func(index int64, validator external.StakingValidatorI) (stop bool) {
-		currValidators[validator.GetOperatorAccountID().String()] = types.NewValidatorGovInfo(
-			validator.GetOperatorAccountID(),
+		currValidators[validator.GetOperator().String()] = types.NewValidatorGovInfo(
+			validator.GetOperator(),
 			validator.GetBondedTokens(),
 			validator.GetDelegatorShares(),
 			sdk.ZeroDec(),
@@ -114,8 +114,8 @@ func (keeper Keeper) EmergencyPass(ctx sdk.Context, proposalID uint64) (passes b
 
 	// fetch all the bonded validators, insert them into currValidators      TotalBondedTokens
 	keeper.sk.IterateBondedValidatorsByPower(ctx, func(index int64, validator external.StakingValidatorI) (stop bool) {
-		currValidators[validator.GetOperatorAccountID().String()] = types.NewValidatorGovInfo(
-			validator.GetOperatorAccountID(),
+		currValidators[validator.GetOperator().String()] = types.NewValidatorGovInfo(
+			validator.GetOperator(),
 			validator.GetBondedTokens(),
 			validator.GetDelegatorShares(),
 			sdk.ZeroDec(),

--- a/x/slashing/simulation/operations.go
+++ b/x/slashing/simulation/operations.go
@@ -55,7 +55,7 @@ func SimulateMsgUnjail(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Kee
 			return simulation.NoOpMsg(types.ModuleName), nil, nil // skip
 		}
 
-		simAccount, found := simulation.FindAccount(accs, sdk.AccAddress(validator.GetOperator()))
+		simAccount, found := simulation.FindAccount(accs, sdk.AccAddress(validator.GetOperatorAddress()))
 		if !found {
 			return simulation.NoOpMsg(types.ModuleName), nil, nil // skip
 		}
@@ -73,12 +73,12 @@ func SimulateMsgUnjail(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Kee
 
 		// FIXME: sim account use kuchain
 		simAccountID := chainTypes.NewAccountIDFromAccAdd(simAccount.Address)
-		selfDel := sk.Delegation(ctx, simAccountID, validator.GetOperatorAccountID())
+		selfDel := sk.Delegation(ctx, simAccountID, validator.GetOperator())
 		if selfDel == nil {
 			return simulation.NoOpMsg(types.ModuleName), nil, nil // skip
 		}
 
-		account := ak.GetAccount(ctx, validator.GetOperatorAccountID())
+		account := ak.GetAccount(ctx, validator.GetOperator())
 		spendable := bk.SpendableCoins(ctx, account.GetID())
 
 		fees, err := kuSim.RandomFees(r, ctx, spendable)
@@ -86,7 +86,7 @@ func SimulateMsgUnjail(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Kee
 			return simulation.NoOpMsg(types.ModuleName), nil, err
 		}
 
-		msg := types.NewKuMsgUnjail(simAccount.Address, validator.GetOperatorAccountID())
+		msg := types.NewKuMsgUnjail(simAccount.Address, validator.GetOperator())
 
 		tx := helpers.GenTx(
 			[]sdk.Msg{msg},

--- a/x/staking/exported/exported.go
+++ b/x/staking/exported/exported.go
@@ -25,8 +25,8 @@ type ValidatorI interface {
 	IsUnbonded() bool                                       // check if has status unbonded
 	IsUnbonding() bool                                      // check if has status unbonding
 	InvalidExRate() bool                                    // check if invalid ex rate
-	GetOperator() sdk.ValAddress                            // operator address to receive/return validators coins
-	GetOperatorAccountID() types.AccountID                  // operator account to receive/return validators coins
+	GetOperatorAddress() sdk.ValAddress                     // operator address to receive/return validators coins
+	GetOperator() types.AccountID                           // operator account to receive/return validators coins
 	GetConsPubKey() crypto.PubKey                           // validation consensus pubkey
 	GetConsAddr() sdk.ConsAddress                           // validation consensus address
 	GetTokens() sdk.Int                                     // validation tokens

--- a/x/staking/genesis.go
+++ b/x/staking/genesis.go
@@ -188,7 +188,7 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) types.GenesisState {
 func WriteValidators(ctx sdk.Context, keeper Keeper) (vals []chainTypes.GenesisValidator) {
 	keeper.IterateLastValidators(ctx, func(_ int64, validator statkingexport.ValidatorI) (stop bool) {
 		vals = append(vals, chainTypes.GenesisValidator{
-			ID:      validator.GetOperatorAccountID(),
+			ID:      validator.GetOperator(),
 			Address: bytes.HexBytes(sdk.GetConsAddress(validator.GetConsPubKey())),
 			PubKey:  validator.GetConsPubKey(),
 			Power:   validator.GetConsensusPower(),

--- a/x/staking/keeper/delegation_test.go
+++ b/x/staking/keeper/delegation_test.go
@@ -8,10 +8,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 
+	"time"
+
 	chainTypes "github.com/KuChainNetwork/kuchain/chain/types"
 	"github.com/KuChainNetwork/kuchain/test/simapp"
 	. "github.com/smartystreets/goconvey/convey"
-	"time"
 )
 
 func TestDelegation(t *testing.T) {
@@ -100,11 +101,11 @@ func TestDelegation(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			resVal, err := keeper.GetDelegatorValidator(ctx, Accdel[0], Accd[i])
 			So(err, ShouldBeNil)
-			So(Accd[i].Eq(resVal.GetOperatorAccountID()), ShouldBeTrue)
+			So(Accd[i].Eq(resVal.GetOperator()), ShouldBeTrue)
 
 			resVal, err = keeper.GetDelegatorValidator(ctx, Accdel[1], Accd[i])
 			So(err, ShouldBeNil)
-			So(Accd[i].Eq(resVal.GetOperatorAccountID()), ShouldBeTrue)
+			So(Accd[i].Eq(resVal.GetOperator()), ShouldBeTrue)
 
 			resDels := keeper.GetValidatorDelegations(ctx, Accd[i])
 			So(len(resDels) == 2, ShouldBeTrue)

--- a/x/staking/keeper/invariants.go
+++ b/x/staking/keeper/invariants.go
@@ -162,7 +162,7 @@ func DelegatorSharesInvariant(k Keeper) sdk.Invariant {
 			valTotalDelShares := validator.GetDelegatorShares()
 
 			totalDelShares := sdk.ZeroDec()
-			delegations := k.GetValidatorDelegations(ctx, validator.GetOperatorAccountID())
+			delegations := k.GetValidatorDelegations(ctx, validator.GetOperator())
 			for _, delegation := range delegations {
 				totalDelShares = totalDelShares.Add(delegation.Shares)
 			}

--- a/x/staking/keeper/querier_test.go
+++ b/x/staking/keeper/querier_test.go
@@ -465,10 +465,10 @@ func TestQuerier(t *testing.T) {
 		_ = keeper.ApplyAndReturnValidatorSetUpdates(ctx)
 
 		rdAmount := exported.TokensFromConsensusPower(20)
-		keeper.BeginRedelegation(ctx, addrAcc2, val1.GetOperatorAccountID(), val2.GetOperatorAccountID(), rdAmount.ToDec())
+		keeper.BeginRedelegation(ctx, addrAcc2, val1.GetOperator(), val2.GetOperator(), rdAmount.ToDec())
 		keeper.ApplyAndReturnValidatorSetUpdates(ctx)
 
-		redel, found := keeper.GetRedelegation(ctx, addrAcc2, val1.GetOperatorAccountID(), val2.GetOperatorAccountID())
+		redel, found := keeper.GetRedelegation(ctx, addrAcc2, val1.GetOperator(), val2.GetOperator())
 		require.True(t, found)
 
 		// delegator redelegations
@@ -495,7 +495,7 @@ func TestQuerier(t *testing.T) {
 		require.Len(t, redel.Entries, len(redelRes[0].Entries))
 
 		// validator redelegations
-		queryValidatorParams := types.NewQueryValidatorParams(val1.GetOperatorAccountID())
+		queryValidatorParams := types.NewQueryValidatorParams(val1.GetOperator())
 		bz, errRes = cdc.MarshalJSON(queryValidatorParams)
 		require.NoError(t, errRes)
 
@@ -543,7 +543,7 @@ func TestQuerier(t *testing.T) {
 
 		// undelegate
 		undelAmount := sdk.TokensFromConsensusPower(20)
-		_, err = keeper.Undelegate(ctx, addrAcc1, val1.GetOperatorAccountID(), undelAmount.ToDec())
+		_, err = keeper.Undelegate(ctx, addrAcc1, val1.GetOperator(), undelAmount.ToDec())
 		require.NoError(t, err)
 		keeper.ApplyAndReturnValidatorSetUpdates(ctx)
 
@@ -553,7 +553,7 @@ func TestQuerier(t *testing.T) {
 		//
 		// found: query unbonding delegation by delegator and validator
 		//
-		queryValidatorParams := types.NewQueryBondsParams(addrAcc1, val1.GetOperatorAccountID())
+		queryValidatorParams := types.NewQueryBondsParams(addrAcc1, val1.GetOperator())
 		bz, errRes := cdc.MarshalJSON(queryValidatorParams)
 		require.NoError(t, errRes)
 		query := abci.RequestQuery{
@@ -572,7 +572,7 @@ func TestQuerier(t *testing.T) {
 		//
 		// not found: query unbonding delegation by delegator and validator
 		//
-		queryValidatorParams = types.NewQueryBondsParams(addrAcc2, val1.GetOperatorAccountID())
+		queryValidatorParams = types.NewQueryBondsParams(addrAcc2, val1.GetOperator())
 		bz, errRes = cdc.MarshalJSON(queryValidatorParams)
 		require.NoError(t, errRes)
 		query = abci.RequestQuery{

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -50,10 +50,10 @@ func (k Keeper) Slash(ctx sdk.Context, consAddr sdk.ConsAddress, infractionHeigh
 
 	// should not be slashing an unbonded validator
 	if validator.IsUnbonded() {
-		panic(fmt.Sprintf("should not be slashing unbonded validator: %s", validator.GetOperatorAccountID()))
+		panic(fmt.Sprintf("should not be slashing unbonded validator: %s", validator.GetOperator()))
 	}
 
-	operatorAccount := validator.GetOperatorAccountID()
+	operatorAccount := validator.GetOperator()
 
 	// call the before-modification hook
 	k.BeforeValidatorModified(ctx, operatorAccount)
@@ -136,7 +136,7 @@ func (k Keeper) Slash(ctx sdk.Context, consAddr sdk.ConsAddress, infractionHeigh
 	// Log that a slash occurred!
 	logger.Info(fmt.Sprintf(
 		"validator %s slashed by slash factor of %s; burned %v tokens",
-		validator.GetOperatorAccountID().String(), slashFactor.String(), tokensToBurn))
+		validator.GetOperator().String(), slashFactor.String(), tokensToBurn))
 }
 
 // jail a validator
@@ -316,10 +316,10 @@ func (k Keeper) SlashByValidatorAccount(ctx sdk.Context, valAccount AccountID, i
 	slashAmount := slashAmountDec.TruncateInt()
 	// should not be slashing an unbonded validator
 	if validator.IsUnbonded() {
-		panic(fmt.Sprintf("should not be slashing unbonded validator: %s", validator.GetOperatorAccountID().String()))
+		panic(fmt.Sprintf("should not be slashing unbonded validator: %s", validator.GetOperator().String()))
 	}
 
-	operatorAccount := validator.GetOperatorAccountID()
+	operatorAccount := validator.GetOperator()
 
 	k.BeforeValidatorModified(ctx, operatorAccount)
 
@@ -395,5 +395,5 @@ func (k Keeper) SlashByValidatorAccount(ctx sdk.Context, valAccount AccountID, i
 
 	logger.Info(fmt.Sprintf(
 		"validator %s slashed by slash factor of %s; burned %v tokens",
-		validator.GetOperatorAccountID().String(), slashFactor.String(), tokensToBurn))
+		validator.GetOperator().String(), slashFactor.String(), tokensToBurn))
 }

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -155,7 +155,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx sdk.Context) (updates []ab
 		validatorNoLonger := k.mustGetValidator(ctx, NewAccountIDFromByte(valAddrBytes))
 		validatorNoLonger = k.bondedToUnbonding(ctx, validatorNoLonger)
 		amtFromBondedToNotBonded = amtFromBondedToNotBonded.Add(validatorNoLonger.GetTokens())
-		k.DeleteLastValidatorPower(ctx, validatorNoLonger.GetOperatorAccountID())
+		k.DeleteLastValidatorPower(ctx, validatorNoLonger.GetOperator())
 		updates = append(updates, validatorNoLonger.ABCIValidatorUpdateZero())
 	}
 

--- a/x/staking/simulation/operations.go
+++ b/x/staking/simulation/operations.go
@@ -187,7 +187,7 @@ func SimulateMsgEditValidator(ak types.AccountKeeper, bk types.BankKeeper, k kee
 			return simulation.NoOpMsg(types.ModuleName), nil, nil
 		}
 
-		address := val.GetOperator()
+		address := val.GetOperatorAddress()
 
 		newCommissionRate := simulation.RandomDecAmount(r, val.GetCommissionMaxRate())
 
@@ -196,9 +196,9 @@ func SimulateMsgEditValidator(ak types.AccountKeeper, bk types.BankKeeper, k kee
 			return simulation.NoOpMsg(types.ModuleName), nil, nil
 		}
 
-		simAccount, found := simulation.FindAccount(accs, sdk.AccAddress(val.GetOperator()))
+		simAccount, found := simulation.FindAccount(accs, sdk.AccAddress(val.GetOperatorAddress()))
 		if !found {
-			return simulation.NoOpMsg(types.ModuleName), nil, fmt.Errorf("validator %s not found", val.GetOperator())
+			return simulation.NoOpMsg(types.ModuleName), nil, fmt.Errorf("validator %s not found", val.GetOperatorAddress())
 		}
 
 		id := chainTypes.NewAccountIDFromAdd(simAccount.Address)
@@ -219,7 +219,7 @@ func SimulateMsgEditValidator(ak types.AccountKeeper, bk types.BankKeeper, k kee
 			simulation.RandStringOfLength(r, 10),
 		)
 
-		accountID := val.GetOperatorAccountID()
+		accountID := val.GetOperator()
 		//lose accaddress
 		msg := types.NewKuMsgEditValidator(sdk.AccAddress(address), accountID, description, &newCommissionRate)
 
@@ -290,7 +290,7 @@ func SimulateMsgDelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper.K
 			}
 		}
 
-		msg := types.NewKuMsgDelegate(simAccount.Address, chainTypes.NewAccountIDFromAccAdd(simAccount.Address), val.GetOperatorAccountID(), bondAmt)
+		msg := types.NewKuMsgDelegate(simAccount.Address, chainTypes.NewAccountIDFromAccAdd(simAccount.Address), val.GetOperator(), bondAmt)
 
 		tx := helpers.GenTx(
 			[]sdk.Msg{msg},
@@ -323,9 +323,9 @@ func SimulateMsgUndelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper
 		if !ok {
 			return simulation.NoOpMsg(types.ModuleName), nil, nil
 		}
-		valAddr := validator.GetOperatorAccountID()
+		valAddr := validator.GetOperator()
 
-		delegations := k.GetValidatorDelegations(ctx, validator.GetOperatorAccountID())
+		delegations := k.GetValidatorDelegations(ctx, validator.GetOperator())
 
 		// get random delegator from validator
 		delegation := delegations[r.Intn(len(delegations))]
@@ -407,7 +407,7 @@ func SimulateMsgBeginRedelegate(ak types.AccountKeeper, bk types.BankKeeper, k k
 			return simulation.NoOpMsg(types.ModuleName), nil, nil
 		}
 
-		srcAddr := srcVal.GetOperatorAccountID()
+		srcAddr := srcVal.GetOperator()
 		delegations := k.GetValidatorDelegations(ctx, srcAddr)
 
 		// get random delegator from src validator
@@ -423,7 +423,7 @@ func SimulateMsgBeginRedelegate(ak types.AccountKeeper, bk types.BankKeeper, k k
 		if !ok {
 			return simulation.NoOpMsg(types.ModuleName), nil, nil
 		}
-		destAddr := destVal.GetOperatorAccountID()
+		destAddr := destVal.GetOperator()
 
 		if srcAddr.Eq(destAddr) ||
 			destVal.InvalidExRate() ||

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -416,11 +416,11 @@ func (v Validator) MinEqual(other Validator) bool {
 }
 
 // nolint - for ValidatorI
-func (v Validator) IsJailed() bool                        { return v.Jailed }
-func (v Validator) GetMoniker() string                    { return v.Description.Moniker }
-func (v Validator) GetStatus() exported.BondStatus        { return v.Status }
-func (v Validator) GetOperatorAccountID() types.AccountID { return v.OperatorAccount }
-func (v Validator) GetOperator() sdk.ValAddress {
+func (v Validator) IsJailed() bool                 { return v.Jailed }
+func (v Validator) GetMoniker() string             { return v.Description.Moniker }
+func (v Validator) GetStatus() exported.BondStatus { return v.Status }
+func (v Validator) GetOperator() types.AccountID   { return v.OperatorAccount }
+func (v Validator) GetOperatorAddress() sdk.ValAddress {
 	operatorAccAddress, _ := v.OperatorAccount.ToAccAddress()
 	return sdk.ValAddress(operatorAccAddress)
 }


### PR DESCRIPTION
## Summary

Most Api of kratos should use accountID, in last version there is some api like `xxxAccountID`, so need change.

closes: #XXXX

## Modifys

<!-- Some modifys desc for this PR commits -->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes