### PR TITLE
Add Precheck symbol state for dex create symbol cli

### DIFF
--- a/x/dex/client/cli/tx.go
+++ b/x/dex/client/cli/tx.go
@@ -204,6 +204,17 @@ func CreateSymbol(cdc *codec.Codec) *cobra.Command {
 				return
 			}
 
+			var symbol types.Symbol
+			getter := types.NewDexRetriever(cliCtx)
+			if symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode); err == nil && symbol.Base.Validate() && symbol.Quote.Validate() {
+				err = errors.Wrapf(types.ErrSymbolExists, "symbol %s/%s:%s/%s exists",
+					baseCreator,
+					baseCode,
+					quoteCreator,
+					quoteCode)
+				return
+			}
+
 			err = txutil.GenerateOrBroadcastMsgs(ctx, txBldr, []sdk.Msg{
 				types.NewMsgCreateSymbol(
 					auth,
@@ -294,6 +305,17 @@ func UpdateSymbol(cdc *codec.Codec) *cobra.Command {
 				return
 			}
 
+			var symbol types.Symbol
+			getter := types.NewDexRetriever(cliCtx)
+			if symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode); err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
+				err = errors.Wrapf(types.ErrSymbolExists, "symbol %s/%s:%s/%s not exists",
+					baseCreator,
+					baseCode,
+					quoteCreator,
+					quoteCode)
+				return
+			}
+
 			err = txutil.GenerateOrBroadcastMsgs(ctx, txBldr, []sdk.Msg{
 				types.NewMsgUpdateSymbol(
 					auth,
@@ -357,6 +379,27 @@ func PauseSymbol(cdc *codec.Codec) *cobra.Command {
 				err = errors.Wrapf(err, "pause symbol account %s auth error", creator)
 				return
 			}
+
+			var symbol types.Symbol
+			getter := types.NewDexRetriever(cliCtx)
+			if symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode); err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
+				err = errors.Wrapf(types.ErrSymbolExists, "symbol %s/%s:%s/%s not exists",
+					baseCreator,
+					baseCode,
+					quoteCreator,
+					quoteCode)
+				return
+			}
+
+			if symbol.IsPaused {
+				err = errors.Wrapf(types.ErrSymbolStateError, "symbol %s/%s:%s/%s was paused",
+					baseCreator,
+					baseCode,
+					quoteCreator,
+					quoteCode)
+				return
+			}
+
 			err = txutil.GenerateOrBroadcastMsgs(ctx, txBldr, []sdk.Msg{
 				types.NewMsgPauseSymbol(auth, creator, baseCreator, baseCode, quoteCreator, quoteCode),
 			})
@@ -397,6 +440,27 @@ func RestoreSymbol(cdc *codec.Codec) *cobra.Command {
 				err = errors.Wrapf(err, "restore symbol account %s auth error", creator)
 				return
 			}
+
+			var symbol types.Symbol
+			getter := types.NewDexRetriever(cliCtx)
+			if symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode); err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
+				err = errors.Wrapf(types.ErrSymbolExists, "symbol %s/%s:%s/%s not exists",
+					baseCreator,
+					baseCode,
+					quoteCreator,
+					quoteCode)
+				return
+			}
+
+			if !symbol.IsPaused {
+				err = errors.Wrapf(types.ErrSymbolStateError, "symbol %s/%s:%s/%s did not paused",
+					baseCreator,
+					baseCode,
+					quoteCreator,
+					quoteCode)
+				return
+			}
+
 			err = txutil.GenerateOrBroadcastMsgs(ctx, txBldr, []sdk.Msg{
 				types.NewMsgRestoreSymbol(auth, creator, baseCreator, baseCode, quoteCreator, quoteCode),
 			})
@@ -437,6 +501,18 @@ func ShutdownSymbol(cdc *codec.Codec) *cobra.Command {
 				err = errors.Wrapf(err, "shutdown symbol account %s auth error", creator)
 				return
 			}
+
+			var symbol types.Symbol
+			getter := types.NewDexRetriever(cliCtx)
+			if symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode); err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
+				err = errors.Wrapf(types.ErrSymbolExists, "symbol %s/%s:%s/%s not exists",
+					baseCreator,
+					baseCode,
+					quoteCreator,
+					quoteCode)
+				return
+			}
+
 			err = txutil.GenerateOrBroadcastMsgs(ctx, txBldr, []sdk.Msg{
 				types.NewMsgShutdownSymbol(auth, creator, baseCreator, baseCode, quoteCreator, quoteCode),
 			})

--- a/x/dex/client/cli/tx.go
+++ b/x/dex/client/cli/tx.go
@@ -206,7 +206,8 @@ func CreateSymbol(cdc *codec.Codec) *cobra.Command {
 
 			var symbol types.Symbol
 			getter := types.NewDexRetriever(cliCtx)
-			if symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode); err == nil && symbol.Base.Validate() && symbol.Quote.Validate() {
+			symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode)
+			if err == nil && symbol.Base.Validate() && symbol.Quote.Validate() {
 				err = errors.Wrapf(types.ErrSymbolExists, "symbol %s/%s:%s/%s exists",
 					baseCreator,
 					baseCode,
@@ -307,7 +308,8 @@ func UpdateSymbol(cdc *codec.Codec) *cobra.Command {
 
 			var symbol types.Symbol
 			getter := types.NewDexRetriever(cliCtx)
-			if symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode); err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
+			symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode)
+			if err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
 				err = errors.Wrapf(types.ErrSymbolExists, "symbol %s/%s:%s/%s not exists",
 					baseCreator,
 					baseCode,
@@ -382,7 +384,8 @@ func PauseSymbol(cdc *codec.Codec) *cobra.Command {
 
 			var symbol types.Symbol
 			getter := types.NewDexRetriever(cliCtx)
-			if symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode); err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
+			symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode)
+			if err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
 				err = errors.Wrapf(types.ErrSymbolExists, "symbol %s/%s:%s/%s not exists",
 					baseCreator,
 					baseCode,
@@ -443,7 +446,8 @@ func RestoreSymbol(cdc *codec.Codec) *cobra.Command {
 
 			var symbol types.Symbol
 			getter := types.NewDexRetriever(cliCtx)
-			if symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode); err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
+			symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode)
+			if err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
 				err = errors.Wrapf(types.ErrSymbolExists, "symbol %s/%s:%s/%s not exists",
 					baseCreator,
 					baseCode,
@@ -504,7 +508,8 @@ func ShutdownSymbol(cdc *codec.Codec) *cobra.Command {
 
 			var symbol types.Symbol
 			getter := types.NewDexRetriever(cliCtx)
-			if symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode); err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
+			symbol, _, err = getter.GetSymbolWithHeight(creator, baseCreator, baseCode, quoteCreator, quoteCode)
+			if err != nil || !symbol.Base.Validate() || !symbol.Quote.Validate() {
 				err = errors.Wrapf(types.ErrSymbolExists, "symbol %s/%s:%s/%s not exists",
 					baseCreator,
 					baseCode,

--- a/x/dex/client/cli/tx.go
+++ b/x/dex/client/cli/tx.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bufio"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -181,19 +180,19 @@ func CreateSymbol(cdc *codec.Codec) *cobra.Command {
 				quoteIconURL,
 				quoteTxURL := args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12]
 
-			if 0 >= len(baseCreator) ||
-				0 >= len(baseCode) ||
-				0 >= len(baseName) ||
-				0 >= len(baseFullName) ||
-				0 >= len(quoteCreator) ||
-				0 >= len(baseIconURL) ||
-				0 >= len(baseTxURL) ||
-				0 >= len(quoteCode) ||
-				0 >= len(quoteName) ||
-				0 >= len(quoteFullName) ||
-				0 >= len(quoteIconURL) ||
-				0 >= len(quoteTxURL) {
-				err = errors.Errorf("all update failed are empty")
+			if baseCreator == "" ||
+				baseCode == "" ||
+				baseName == "" ||
+				baseFullName == "" ||
+				quoteCreator == "" ||
+				baseIconURL == "" ||
+				baseTxURL == "" ||
+				quoteCode == "" ||
+				quoteName == "" ||
+				quoteFullName == "" ||
+				quoteIconURL == "" ||
+				quoteTxURL == "" {
+				err = errors.Errorf("params failed by all params for dex symbol should not empty")
 				return
 			}
 
@@ -240,7 +239,6 @@ func CreateSymbol(cdc *codec.Codec) *cobra.Command {
 							TxURL:    quoteTxURL,
 						},
 					},
-					time.Time{}, // use server time
 				),
 			})
 

--- a/x/dex/client/rest/tx.go
+++ b/x/dex/client/rest/tx.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -255,7 +254,6 @@ func createSymbolHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 				name,
 				&req.Base,
 				&req.Quote,
-				time.Time{}, // use server time
 			),
 		})
 	}

--- a/x/dex/handler.go
+++ b/x/dex/handler.go
@@ -3,7 +3,6 @@ package dex
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/KuChainNetwork/kuchain/chain/msg"
 	chainTypes "github.com/KuChainNetwork/kuchain/chain/types"
@@ -158,15 +157,10 @@ func handleMsgCreateSymbol(ctx chainTypes.Context,
 	logger.Debug("handle create symbol", "creator", data.Creator)
 
 	if err := keeper.CreateSymbol(ctx.Context(), data.Creator, &types.Symbol{
-		Base:   data.Base,
-		Quote:  data.Quote,
-		Height: ctx.BlockHeight(),
-		CreateTime: func() time.Time {
-			if data.CreateTime.IsZero() {
-				return ctx.BlockTime()
-			}
-			return data.CreateTime
-		}(),
+		Base:       data.Base,
+		Quote:      data.Quote,
+		Height:     ctx.BlockHeight(),
+		CreateTime: ctx.BlockTime(),
 	}); err != nil {
 		return nil, errors.Wrapf(err,
 			"msg create symbol error, creator %s",

--- a/x/dex/handler_test.go
+++ b/x/dex/handler_test.go
@@ -403,8 +403,7 @@ func TestHandleCreateSymbol(t *testing.T) {
 		msgCreateSymbol := dexTypes.NewMsgCreateSymbol(auth,
 			accName,
 			&symbol.Base,
-			&symbol.Quote,
-			symbol.CreateTime)
+			&symbol.Quote)
 
 		So(msgCreateSymbol.ValidateBasic(), ShouldBeNil)
 
@@ -417,14 +416,20 @@ func TestHandleCreateSymbol(t *testing.T) {
 		err := simapp.CheckTxs(t, app, ctx, tx)
 		So(err, ShouldBeNil)
 
+		symbolCreateHeight := ctx.BlockHeight()
+		symbolCreateTime := ctx.BlockTime()
+
 		simapp.AfterBlockCommitted(app, 1)
 
 		ctx = app.NewTestContext()
 		dex, ok = app.DexKeeper().GetDex(ctx, accName)
 		So(ok, ShouldBeTrue)
+
 		savedSymbol, ok := dex.Symbol(symbol.Base.Creator, symbol.Base.Code, symbol.Quote.Creator, symbol.Quote.Code)
 		So(ok, ShouldBeTrue)
-		symbol.Height = savedSymbol.Height // ignore height check
+
+		symbol.Height = symbolCreateHeight
+		symbol.CreateTime = symbolCreateTime
 		So(savedSymbol.Equal(symbol), ShouldBeTrue)
 
 		simapp.AfterBlockCommitted(app, 1)
@@ -433,8 +438,7 @@ func TestHandleCreateSymbol(t *testing.T) {
 		msgCreateSymbol = dexTypes.NewMsgCreateSymbol(auth,
 			accName,
 			&symbol.Base,
-			&symbol.Quote,
-			symbol.CreateTime)
+			&symbol.Quote)
 
 		So(msgCreateSymbol.ValidateBasic(), ShouldBeNil)
 
@@ -447,14 +451,20 @@ func TestHandleCreateSymbol(t *testing.T) {
 		err = simapp.CheckTxs(t, app, ctx, tx)
 		So(err, ShouldBeNil)
 
+		symbolCreateHeight = ctx.BlockHeight()
+		symbolCreateTime = ctx.BlockTime()
+
 		simapp.AfterBlockCommitted(app, 1)
 
 		ctx = app.NewTestContext()
 		dex, ok = app.DexKeeper().GetDex(ctx, accName)
 		So(ok, ShouldBeTrue)
+
 		savedSymbol, ok = dex.Symbol(symbol.Base.Creator, symbol.Base.Code, symbol.Quote.Creator, symbol.Quote.Code)
 		So(ok, ShouldBeTrue)
-		symbol.Height = savedSymbol.Height // ignore height check
+
+		symbol.Height = symbolCreateHeight
+		symbol.CreateTime = symbolCreateTime
 		So(savedSymbol.Equal(symbol), ShouldBeTrue)
 
 		invalidSymbol := symbol
@@ -462,16 +472,14 @@ func TestHandleCreateSymbol(t *testing.T) {
 		So(dexTypes.NewMsgCreateSymbol(auth,
 			accName,
 			&invalidSymbol.Base,
-			&invalidSymbol.Quote,
-			invalidSymbol.CreateTime).ValidateBasic(), ShouldNotBeNil)
+			&invalidSymbol.Quote).ValidateBasic(), ShouldNotBeNil)
 
 		invalidSymbol = symbol
 		invalidSymbol.Quote.Code = ""
 		So(dexTypes.NewMsgCreateSymbol(auth,
 			accName,
 			&invalidSymbol.Base,
-			&invalidSymbol.Quote,
-			invalidSymbol.CreateTime).ValidateBasic(), ShouldNotBeNil)
+			&invalidSymbol.Quote).ValidateBasic(), ShouldNotBeNil)
 
 		invalidSymbol = symbol
 		invalidSymbol.Base.Code = ""
@@ -479,8 +487,7 @@ func TestHandleCreateSymbol(t *testing.T) {
 		So(dexTypes.NewMsgCreateSymbol(auth,
 			accName,
 			&invalidSymbol.Base,
-			&invalidSymbol.Quote,
-			invalidSymbol.CreateTime).ValidateBasic(), ShouldNotBeNil)
+			&invalidSymbol.Quote).ValidateBasic(), ShouldNotBeNil)
 
 		invalidSymbol = symbol
 		invalidSymbol.Base.Code = "coin1"
@@ -489,8 +496,7 @@ func TestHandleCreateSymbol(t *testing.T) {
 		So(dexTypes.NewMsgCreateSymbol(auth,
 			accName,
 			&invalidSymbol.Base,
-			&invalidSymbol.Quote,
-			invalidSymbol.CreateTime).ValidateBasic(), ShouldNotBeNil)
+			&invalidSymbol.Quote).ValidateBasic(), ShouldNotBeNil)
 	})
 }
 
@@ -545,8 +551,7 @@ func TestHandleUpdateSymbol(t *testing.T) {
 		msgCreateSymbol := dexTypes.NewMsgCreateSymbol(auth,
 			accName,
 			&symbol.Base,
-			&symbol.Quote,
-			symbol.CreateTime)
+			&symbol.Quote)
 		So(msgCreateSymbol.ValidateBasic(), ShouldBeNil)
 
 		tx := simapp.NewTxForTest(
@@ -558,14 +563,20 @@ func TestHandleUpdateSymbol(t *testing.T) {
 		err := simapp.CheckTxs(t, app, ctx, tx)
 		So(err, ShouldBeNil)
 
+		symbolCreateHeight := ctx.BlockHeight()
+		symbolCreateTime := ctx.BlockTime()
+
 		simapp.AfterBlockCommitted(app, 1)
 
 		ctx = app.NewTestContext()
 		dex, ok = app.DexKeeper().GetDex(ctx, accName)
 		So(ok, ShouldBeTrue)
+
 		savedSymbol, ok := dex.Symbol(symbol.Base.Creator, symbol.Base.Code, symbol.Quote.Creator, symbol.Quote.Code)
 		So(ok, ShouldBeTrue)
-		symbol.Height = savedSymbol.Height // ignore height check
+
+		symbol.Height = symbolCreateHeight
+		symbol.CreateTime = symbolCreateTime
 		So(savedSymbol.Equal(symbol), ShouldBeTrue)
 
 		copiedSymbol := *symbol
@@ -680,8 +691,7 @@ func TestHandlePauseSymbol(t *testing.T) {
 		msgCreateSymbol := dexTypes.NewMsgCreateSymbol(auth,
 			accName,
 			&symbol.Base,
-			&symbol.Quote,
-			symbol.CreateTime)
+			&symbol.Quote)
 		So(msgCreateSymbol.ValidateBasic(), ShouldBeNil)
 
 		tx := simapp.NewTxForTest(
@@ -693,14 +703,20 @@ func TestHandlePauseSymbol(t *testing.T) {
 		err := simapp.CheckTxs(t, app, ctx, tx)
 		So(err, ShouldBeNil)
 
+		symbolCreateHeight := ctx.BlockHeight()
+		symbolCreateTime := ctx.BlockTime()
+
 		simapp.AfterBlockCommitted(app, 1)
 
 		ctx = app.NewTestContext()
 		dex, ok = app.DexKeeper().GetDex(ctx, accName)
 		So(ok, ShouldBeTrue)
+
 		savedSymbol, ok := dex.Symbol(symbol.Base.Creator, symbol.Base.Code, symbol.Quote.Creator, symbol.Quote.Code)
 		So(ok, ShouldBeTrue)
-		symbol.Height = savedSymbol.Height // ignore height check
+
+		symbol.Height = symbolCreateHeight
+		symbol.CreateTime = symbolCreateTime
 		So(savedSymbol.Equal(&symbol), ShouldBeTrue)
 
 		msgPauseSymbol := dexTypes.NewMsgPauseSymbol(auth,
@@ -814,8 +830,7 @@ func TestHandleRestoreSymbol(t *testing.T) {
 		msgCreateSymbol := dexTypes.NewMsgCreateSymbol(auth,
 			accName,
 			&symbol.Base,
-			&symbol.Quote,
-			symbol.CreateTime)
+			&symbol.Quote)
 		So(msgCreateSymbol.ValidateBasic(), ShouldBeNil)
 
 		tx := simapp.NewTxForTest(
@@ -827,14 +842,20 @@ func TestHandleRestoreSymbol(t *testing.T) {
 		err := simapp.CheckTxs(t, app, ctx, tx)
 		So(err, ShouldBeNil)
 
+		symbolCreateHeight := ctx.BlockHeight()
+		symbolCreateTime := ctx.BlockTime()
+
 		simapp.AfterBlockCommitted(app, 1)
 
 		ctx = app.NewTestContext()
 		dex, ok = app.DexKeeper().GetDex(ctx, accName)
 		So(ok, ShouldBeTrue)
+
 		savedSymbol, ok := dex.Symbol(symbol.Base.Creator, symbol.Base.Code, symbol.Quote.Creator, symbol.Quote.Code)
 		So(ok, ShouldBeTrue)
-		symbol.Height = savedSymbol.Height // ignore height check
+
+		symbol.Height = symbolCreateHeight
+		symbol.CreateTime = symbolCreateTime
 		So(savedSymbol.Equal(&symbol), ShouldBeTrue)
 
 		msgPauseSymbol := dexTypes.NewMsgPauseSymbol(auth,
@@ -978,8 +999,7 @@ func TestShutdownSymbol(t *testing.T) {
 		msgCreateSymbol := dexTypes.NewMsgCreateSymbol(auth,
 			accName,
 			&symbol.Base,
-			&symbol.Quote,
-			symbol.CreateTime)
+			&symbol.Quote)
 		So(msgCreateSymbol.ValidateBasic(), ShouldBeNil)
 
 		tx := simapp.NewTxForTest(
@@ -991,14 +1011,20 @@ func TestShutdownSymbol(t *testing.T) {
 		err := simapp.CheckTxs(t, app, ctx, tx)
 		So(err, ShouldBeNil)
 
+		symbolCreateHeight := ctx.BlockHeight()
+		symbolCreateTime := ctx.BlockTime()
+
 		simapp.AfterBlockCommitted(app, 1)
 
 		ctx = app.NewTestContext()
 		dex, ok = app.DexKeeper().GetDex(ctx, accName)
 		So(ok, ShouldBeTrue)
+
 		savedSymbol, ok := dex.Symbol(symbol.Base.Creator, symbol.Base.Code, symbol.Quote.Creator, symbol.Quote.Code)
 		So(ok, ShouldBeTrue)
-		symbol.Height = savedSymbol.Height // ignore height check
+
+		symbol.Height = symbolCreateHeight
+		symbol.CreateTime = symbolCreateTime
 		So(savedSymbol.Equal(&symbol), ShouldBeTrue)
 
 		msgShutdownSymbol := dexTypes.NewMsgShutdownSymbol(auth,

--- a/x/dex/keeper/querier.go
+++ b/x/dex/keeper/querier.go
@@ -3,11 +3,12 @@ package keeper
 import (
 	"github.com/pkg/errors"
 
-	"github.com/KuChainNetwork/kuchain/x/dex/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/KuChainNetwork/kuchain/x/dex/types"
 )
 
 // NewQuerier creates a querier for auth REST endpoints
@@ -18,6 +19,8 @@ func NewQuerier(keeper DexKeeper) sdk.Querier {
 			return queryDex(ctx, req, keeper)
 		case types.QuerySigIn:
 			return querySigIn(ctx, req, keeper)
+		case types.QuerySymbol:
+			return querySymbol(ctx, req, keeper)
 		default:
 			return nil, errors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown query path: %s", path[0])
 		}
@@ -54,6 +57,35 @@ func querySigIn(ctx sdk.Context, req abci.RequestQuery, keeper DexKeeper) ([]byt
 	coins := keeper.GetSigInForDex(ctx, params.Account, params.Dex)
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, coins)
+	if err != nil {
+		return nil, errors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+	}
+
+	return bz, nil
+}
+
+// querySymbol query symbol for dex
+func querySymbol(ctx sdk.Context, req abci.RequestQuery, keeper DexKeeper) ([]byte, error) {
+	var params types.QuerySymbolParams
+	if err := keeper.cdc.UnmarshalJSON(req.Data, &params); err != nil {
+		return nil, errors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+	}
+
+	dex, ok := keeper.getDex(ctx, params.Creator)
+	if dex == nil || !ok {
+		return nil, errors.Wrapf(sdkerrors.ErrUnknownAddress, "dex %s does not exist", params.Creator)
+	}
+
+	symbol, ok := dex.Symbol(params.BaseCreator, params.BaseCode, params.QuoteCode, params.QuoteCreator)
+	if !ok {
+		return nil, errors.Wrapf(types.ErrSymbolNotExists, "%s/%s:%s/%s not exists",
+			params.BaseCreator,
+			params.BaseCode,
+			params.QuoteCreator,
+			params.QuoteCode)
+	}
+
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, symbol)
 	if err != nil {
 		return nil, errors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}

--- a/x/dex/types/errors.go
+++ b/x/dex/types/errors.go
@@ -29,6 +29,7 @@ var (
 	ErrSymbolDexDescriptionSame   = sdkerrors.Register(ModuleName, 20, "dex symbol to change is same as existing")
 	ErrSymbolBaseCreatorEmpty     = sdkerrors.Register(ModuleName, 24, "dex symbol base creator empty")
 	ErrSymbolQuoteCreatorEmpty    = sdkerrors.Register(ModuleName, 25, "dex symbol quote creator empty")
+	ErrSymbolStateError           = sdkerrors.Register(ModuleName, 26, "dex symbol state error")
 )
 
 var (

--- a/x/dex/types/msgs.go
+++ b/x/dex/types/msgs.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"time"
-
 	"github.com/KuChainNetwork/kuchain/chain/msg"
 	"github.com/KuChainNetwork/kuchain/chain/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -205,19 +203,24 @@ func (msg MsgCreateSymbol) ValidateBasic() error {
 	if err := msg.KuMsg.ValidateTransfer(); err != nil {
 		return err
 	}
+
 	data, err := msg.GetData()
 	if err != nil {
 		return err
 	}
+
 	if data.Creator.Empty() {
 		return sdkerrors.Wrap(types.ErrKuMSgNameEmpty, "creator name not empty")
 	}
+
 	if !data.Base.Validate() {
 		return sdkerrors.Wrap(ErrSymbolBaseInvalid, "base part invalid")
 	}
+
 	if !data.Quote.Validate() {
 		return sdkerrors.Wrap(ErrSymbolQuoteInvalid, "quote part invalid")
 	}
+
 	return nil
 }
 
@@ -231,10 +234,9 @@ func (msg MsgCreateSymbol) GetData() (MsgCreateSymbolData, error) {
 
 // MsgCreateSymbolData msg data for delete dex
 type MsgCreateSymbolData struct {
-	Creator    Name          `json:"creator" yaml:"creator"`
-	Base       BaseCurrency  `json:"base" yaml:"base"`
-	Quote      QuoteCurrency `json:"quote" yaml:"quote"`
-	CreateTime time.Time     `json:"create_time" yaml:"create_time"`
+	Creator Name          `json:"creator" yaml:"creator"`
+	Base    BaseCurrency  `json:"base" yaml:"base"`
+	Quote   QuoteCurrency `json:"quote" yaml:"quote"`
 }
 
 func (MsgCreateSymbolData) Type() types.Name { return types.MustName("create@symbol") }
@@ -248,16 +250,14 @@ func NewMsgCreateSymbol(auth types.AccAddress,
 	creator types.Name,
 	base *BaseCurrency,
 	quote *QuoteCurrency,
-	createTime time.Time,
 ) MsgCreateSymbol {
 	return MsgCreateSymbol{
 		KuMsg: *msg.MustNewKuMsg(RouterKeyName,
 			msg.WithAuth(auth),
 			msg.WithData(ModuleCdc, &MsgCreateSymbolData{
-				Creator:    creator,
-				Base:       *base,
-				Quote:      *quote,
-				CreateTime: createTime,
+				Creator: creator,
+				Base:    *base,
+				Quote:   *quote,
 			})),
 	}
 }


### PR DESCRIPTION
## Summary

Add Precheck symbol state for dex create symbol cli

## Modifys

- add precheck for dex create symbol
- delete time in msg

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes